### PR TITLE
Fix checkout loader and define CartItem type

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,4 +133,4 @@ function App() {
   );
 }
 
-export default App
+export default App;

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -204,10 +204,10 @@ const Checkout: React.FC = () => {
             {error && <p className="text-red-500 mb-2">{error}</p>}
             <Button
               type="submit"
-              disabled={loading || items.length === 0}
+              disabled={isLoading || items.length === 0}
               className="w-full"
             >
-              {loading ? 'Procesando...' : 'Realizar Pedido'}
+              {isLoading ? 'Procesando...' : 'Realizar Pedido'}
             </Button>
           </div>
         </form>

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -7,6 +7,16 @@ export interface OrderItem {
   price: number;
 }
 
+// Item stored in the shopping cart
+export interface CartItem {
+  id: string;
+  productId: string;
+  name: string;
+  imageUrl: string;
+  price: number;
+  quantity: number;
+}
+
 export interface Order {
   id: string;
   total: number;


### PR DESCRIPTION
## Summary
- add missing `CartItem` interface
- use `isLoading` when submitting checkout
- fix `export default App` statement

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684dceae44fc8324ae5c20df16732823