### PR TITLE
Fix auth persistence and translate interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,25 +23,25 @@ const HomePage: React.FC = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
           <div className="text-center">
             <h1 className="text-5xl md:text-6xl font-bold text-gray-900 mb-6">
-              Fresh Baked
-              <span className="text-amber-600 block">Every Day</span>
+              Recién horneado
+              <span className="text-amber-600 block">cada día</span>
             </h1>
             <p className="text-xl text-gray-600 mb-8 max-w-2xl mx-auto">
-              From artisan breads to decadent desserts, discover our handcrafted selection 
-              of fresh baked goods made with premium ingredients and traditional techniques.
+              Desde panes artesanales hasta postres deliciosos, descubre nuestra selección
+              elaborada con ingredientes de primera calidad y técnicas tradicionales.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <a
                 href="/shop"
                 className="inline-flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-lg text-white bg-amber-600 hover:bg-amber-700 transition-colors duration-200"
               >
-                Shop Now
+                Comprar ahora
               </a>
               <a
                 href="/shop"
                 className="inline-flex items-center justify-center px-8 py-3 border-2 border-amber-600 text-base font-medium rounded-lg text-amber-600 bg-transparent hover:bg-amber-600 hover:text-white transition-colors duration-200"
               >
-                View Menu
+                Ver menú
               </a>
             </div>
           </div>
@@ -52,8 +52,8 @@ const HomePage: React.FC = () => {
       <div className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">Why Choose Us</h2>
-            <p className="text-lg text-gray-600">Quality ingredients, traditional methods, modern convenience</p>
+            <h2 className="text-3xl font-bold text-gray-900 mb-4">¿Por qué elegirnos?</h2>
+            <p className="text-lg text-gray-600">Ingredientes de calidad, métodos tradicionales y comodidad moderna</p>
           </div>
           
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -61,24 +61,24 @@ const HomePage: React.FC = () => {
               <div className="bg-amber-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                 <span className="text-2xl">🥖</span>
               </div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Fresh Daily</h3>
-              <p className="text-gray-600">All our products are baked fresh every morning using traditional recipes.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Frescura diaria</h3>
+              <p className="text-gray-600">Todos nuestros productos se hornean cada mañana con recetas tradicionales.</p>
             </div>
             
             <div className="text-center">
               <div className="bg-amber-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                 <span className="text-2xl">🚚</span>
               </div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Fast Delivery</h3>
-              <p className="text-gray-600">Quick and reliable delivery service to bring our bakery to your door.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Entrega rápida</h3>
+              <p className="text-gray-600">Servicio de entrega rápido y confiable que lleva nuestra panadería a tu puerta.</p>
             </div>
             
             <div className="text-center">
               <div className="bg-amber-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
                 <span className="text-2xl">⭐</span>
               </div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Premium Quality</h3>
-              <p className="text-gray-600">We use only the finest ingredients sourced from trusted suppliers.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Calidad premium</h3>
+              <p className="text-gray-600">Utilizamos solo los mejores ingredientes de proveedores de confianza.</p>
             </div>
           </div>
         </div>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -38,7 +38,7 @@ const Header: React.FC = () => {
                 isActive ? 'text-amber-600' : 'text-gray-700 hover:text-amber-600 transition-colors duration-200'
               }
             >
-              Shop
+              Tienda
             </NavLink>
             {user && (
               <NavLink
@@ -47,7 +47,7 @@ const Header: React.FC = () => {
                   isActive ? 'text-amber-600' : 'text-gray-700 hover:text-amber-600 transition-colors duration-200'
                 }
               >
-                My Orders
+                Mis pedidos
               </NavLink>
             )}
             {user?.role === 'admin' && (
@@ -81,7 +81,7 @@ const Header: React.FC = () => {
             {/* User Menu */}
             {user ? (
               <div className="flex items-center space-x-2">
-                <span className="text-sm text-gray-700">Hello, {user.name}</span>
+                <span className="text-sm text-gray-700">Hola, {user.name}</span>
                 <Button
                   variant="outline"
                   size="sm"
@@ -89,14 +89,14 @@ const Header: React.FC = () => {
                   className="flex items-center space-x-1"
                 >
                   <LogOut className="h-4 w-4" />
-                  <span>Logout</span>
+                  <span>Salir</span>
                 </Button>
               </div>
             ) : (
               <Link to="/login">
                 <Button variant="primary" size="sm" className="flex items-center space-x-1">
                   <User className="h-4 w-4" />
-                  <span>Login</span>
+                  <span>Iniciar sesión</span>
                 </Button>
               </Link>
             )}
@@ -126,7 +126,7 @@ const Header: React.FC = () => {
                 }
                 onClick={() => setIsMobileMenuOpen(false)}
               >
-                Shop
+                Tienda
               </NavLink>
               {user && (
                 <NavLink
@@ -136,7 +136,7 @@ const Header: React.FC = () => {
                   }
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
-                  My Orders
+                  Mis pedidos
                 </NavLink>
               )}
               {user?.role === 'admin' && (
@@ -159,7 +159,7 @@ const Header: React.FC = () => {
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   <ShoppingCart className="h-5 w-5" />
-                  <span>Cart ({cartCount})</span>
+                  <span>Carrito ({cartCount})</span>
                 </Link>
 
                 {user ? (
@@ -173,13 +173,13 @@ const Header: React.FC = () => {
                     className="flex items-center space-x-1"
                   >
                     <LogOut className="h-4 w-4" />
-                    <span>Logout</span>
+                    <span>Salir</span>
                   </Button>
                 ) : (
                   <Link to="/login" onClick={() => setIsMobileMenuOpen(false)}>
                     <Button variant="primary" size="sm" className="flex items-center space-x-1">
                       <User className="h-4 w-4" />
-                      <span>Login</span>
+                      <span>Iniciar sesión</span>
                     </Button>
                   </Link>
                 )}

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -33,7 +33,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
 
         {product.stock <= 0 && (
            <div className="absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-             <span className="text-white font-semibold">Out of Stock</span>
+             <span className="text-white font-semibold">Agotado</span>
            </div>
          )}
        </div>
@@ -61,8 +61,8 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
             : 'text-red-600 text-sm' 
           }> 
             {product.stock > 0 
-              ? `In stock: ${product.stock}` 
-              : 'Out of stock' 
+              ? `En stock: ${product.stock}`
+              : 'Agotado'
             } 
           </span>
                     
@@ -73,7 +73,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
             className="flex items-center space-x-1"
           >
             <Plus className="h-4 w-4" />
-            <span>Add</span>
+            <span>Añadir</span>
           </Button>
         </div>
       </div>

--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -13,7 +13,7 @@ interface ProductFormProps {
 const ProductForm: React.FC<ProductFormProps> = ({
   initialData,
   onSubmit,
-  submitLabel = 'Save Product',
+  submitLabel = 'Guardar producto',
   isLoading = false,
 }) => {
   const [formData, setFormData] = useState<ProductFormData>({
@@ -68,7 +68,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
     <form onSubmit={handleSubmit} className="space-y-6">
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <Input
-          label="Product Name"
+          label="Nombre"
           name="name"
           value={formData.name}
           onChange={handleInputChange}
@@ -76,7 +76,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
         />
 
         <Input
-          label="Price ($)"
+          label="Precio ($)"
           name="price"
           type="number"
           step="0.01"
@@ -88,7 +88,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-2">
-          Category
+          Categoría
         </label>
         <select
           name="category"
@@ -97,17 +97,17 @@ const ProductForm: React.FC<ProductFormProps> = ({
           className="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent"
           required
         >
-          <option value="bread">Bread</option>
-          <option value="pastry">Pastry</option>
-          <option value="cake">Cake</option>
-          <option value="cookie">Cookie</option>
-          <option value="dessert">Dessert</option>
+          <option value="bread">Pan</option>
+          <option value="pastry">Pastel</option>
+          <option value="cake">Torta</option>
+          <option value="cookie">Galleta</option>
+          <option value="dessert">Postre</option>
         </select>
       </div>
 
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-2">
-          Description
+          Descripción
         </label>
         <textarea
           name="description"
@@ -120,7 +120,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
       </div>
 
       <Input
-        label="Image URL"
+        label="URL de imagen"
         name="imageUrl"
         value={formData.imageUrl}
         onChange={handleInputChange}
@@ -128,17 +128,17 @@ const ProductForm: React.FC<ProductFormProps> = ({
       />
 
       <Input
-        label="Ingredients (comma-separated)"
+        label="Ingredientes (separados por coma)"
         value={ingredientsText}
         onChange={(e) => setIngredientsText(e.target.value)}
-        helperText="Enter ingredients separated by commas"
+        helperText="Introduce los ingredientes separados por comas"
       />
 
       <Input
-        label="Allergens (comma-separated)"
+        label="Alérgenos (separados por coma)"
         value={allergensText}
         onChange={(e) => setAllergensText(e.target.value)}
-        helperText="Enter allergens separated by commas"
+        helperText="Introduce los alérgenos separados por comas"
       />
 
       <div className="flex items-center">
@@ -151,7 +151,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
           className="h-4 w-4 text-amber-600 focus:ring-amber-500 border-gray-300 rounded"
         />
         <label htmlFor="inStock" className="ml-2 block text-sm text-gray-700">
-          In Stock
+          Disponible
         </label>
       </div>
 

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -49,14 +49,14 @@ const Login: React.FC = () => {
         {/* Formulario */}
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           <Input
-            label="Email"
+            label="Correo"
             type="email"
             value={formData.email}
             onChange={(e) => setFormData({ ...formData, email: e.target.value })}
             required
           />
           <Input
-            label="Password"
+            label="Contraseña"
             type={showPassword ? 'text' : 'password'}
             value={formData.password}
             onChange={(e) => setFormData({ ...formData, password: e.target.value })}
@@ -77,14 +77,14 @@ const Login: React.FC = () => {
             size="lg"
             className="w-full"
           >
-            Sign In
+            Entrar
           </Button>
         </form>
 
         {/* Pie */}
         <div className="text-center">
           <p className="text-xs text-gray-500">
-            Demo credentials: admin@bakery.com / password
+            Credenciales de demo: admin@bakery.com / password
           </p>
         </div>
       </div>

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -14,12 +14,12 @@ const Cart: React.FC = () => {
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <ShoppingBag className="mx-auto h-16 w-16 text-gray-400 mb-4" />
-            <h2 className="text-2xl font-bold text-gray-900 mb-4">Your cart is empty</h2>
+            <h2 className="text-2xl font-bold text-gray-900 mb-4">Tu carrito está vacío</h2>
             <p className="text-gray-600 mb-8">
-              Looks like you haven't added any delicious items to your cart yet.
+              Aún no has añadido ningún delicioso producto a tu carrito.
             </p>
             <Link to="/shop">
-              <Button size="lg">Start Shopping</Button>
+              <Button size="lg">Ir a la tienda</Button>
             </Link>
           </div>
         </div>
@@ -31,13 +31,13 @@ const Cart: React.FC = () => {
     <div className="min-h-screen bg-amber-50 py-8">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">Shopping Cart</h1>
+          <h1 className="text-3xl font-bold text-gray-900">Carrito de compras</h1>
           <Button
             variant="outline"
             onClick={clearCart}
             className="text-red-600 border-red-600 hover:bg-red-600 hover:text-white"
           >
-            Clear Cart
+            Vaciar carrito
           </Button>
         </div>
 
@@ -106,12 +106,12 @@ const Cart: React.FC = () => {
         <div className="mt-8 flex flex-col sm:flex-row gap-4 justify-end">
           <Link to="/shop">
             <Button variant="outline" size="lg" className="w-full sm:w-auto">
-              Continue Shopping
+              Seguir comprando
             </Button>
           </Link>
           <Link to="/checkout">
             <Button size="lg" className="w-full sm:w-auto">
-              Proceed to Checkout
+              Ir a pagar
             </Button>
           </Link>
         </div>

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -90,7 +90,7 @@ const Checkout: React.FC = () => {
     <div className="bg-gray-100 min-h-screen">
       {/* Header removido para evitar duplicado; usa el global */}
       <div className="container mx-auto py-12 px-4">
-        <h2 className="text-3xl font-bold mb-6">Checkout</h2>
+        <h2 className="text-3xl font-bold mb-6">Finalizar compra</h2>
         <form
           onSubmit={handleSubmit}
           className="flex flex-col lg:flex-row gap-8"
@@ -194,9 +194,9 @@ const Checkout: React.FC = () => {
               <span>{formatPrice(total)}</span>
             </div>
             <div className="text-sm text-gray-600 mb-4 space-y-2">
-              <p>• Free delivery for orders over $25</p>
+              <p>• Envío gratis para pedidos superiores a $25</p>
               <p>
-                • You'll receive un email confirmation once your order is confirmed
+                • Recibirás un correo de confirmación cuando tu pedido sea procesado
               </p>
             </div>
             {error && <p className="text-red-500 mb-2">{error}</p>}

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -46,7 +46,7 @@ const OrdersPage: React.FC = () => {
   return (
     <div className="min-h-screen bg-amber-50 py-8">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-8">My Orders</h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-8">Mis pedidos</h1>
 
         {isLoading && user ? (
           <div className="space-y-4">
@@ -63,19 +63,19 @@ const OrdersPage: React.FC = () => {
           </div>
         ) : error && user ? (
           <div className="text-center py-12">
-            <p className="text-red-600">Error loading orders: {error}</p>
+            <p className="text-red-600">Error al cargar pedidos: {error}</p>
           </div>
         ) : displayOrders.length === 0 ? (
           <div className="text-center py-12">
             <Package className="mx-auto h-16 w-16 text-gray-400 mb-4" />
             <h2 className="text-2xl font-bold text-gray-900 mb-4">
-              No orders yet
+              Aún no tienes pedidos
             </h2>
             <p className="text-gray-600">
-              When you place your first order, it will appear here.
+              Cuando hagas tu primer pedido aparecerá aquí.
             </p>
             <Button onClick={() => navigate('/shop')} className="mt-6">
-              Go to Shop
+              Ir a la tienda
             </Button>
           </div>
         ) : (
@@ -91,7 +91,7 @@ const OrdersPage: React.FC = () => {
                       {getStatusIcon(order.status)}
                       <div>
                         <h3 className="text-lg font-semibold text-gray-900">
-                          Order #{order.id.slice(-8)}
+                          Pedido #{order.id.slice(-8)}
                         </h3>
                         <p className="text-sm text-gray-500">
                           {formatDate(order.createdAt)}
@@ -113,7 +113,7 @@ const OrdersPage: React.FC = () => {
                   </div>
 
                   <div className="border-t border-gray-200 pt-4">
-                    <h4 className="font-medium text-gray-900 mb-3">Items:</h4>
+                    <h4 className="font-medium text-gray-900 mb-3">Artículos:</h4>
                     <div className="space-y-2">
                       {order.OrderItems.map((item) => (
                         <div
@@ -131,7 +131,7 @@ const OrdersPage: React.FC = () => {
                                 {item.name}
                               </p>
                               <p className="text-xs text-gray-500">
-                                Qty: {item.quantity}
+                                Cant: {item.quantity}
                               </p>
                             </div>
                           </div>
@@ -148,14 +148,14 @@ const OrdersPage: React.FC = () => {
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                         <div>
                           <p className="font-medium text-gray-900">
-                            Delivery Address:
+                            Dirección de entrega:
                           </p>
                           <p className="text-gray-600">
                             {order.customerInfo.address || '—'}
                           </p>
                         </div>
                         <div>
-                          <p className="font-medium text-gray-900">Contact:</p>
+                          <p className="font-medium text-gray-900">Contacto:</p>
                           <p className="text-gray-600">
                             {order.customerInfo.phone || '—'}
                           </p>

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -21,12 +21,12 @@ const Shop: React.FC = () => {
   });
 
   const categories = [
-    { value: 'all', label: 'All Products' },
-    { value: 'bread', label: 'Bread' },
-    { value: 'pastry', label: 'Pastries' },
-    { value: 'cake', label: 'Cakes' },
-    { value: 'cookie', label: 'Cookies' },
-    { value: 'dessert', label: 'Desserts' },
+    { value: 'all', label: 'Todos' },
+    { value: 'bread', label: 'Pan' },
+    { value: 'pastry', label: 'Pasteles' },
+    { value: 'cake', label: 'Tortas' },
+    { value: 'cookie', label: 'Galletas' },
+    { value: 'dessert', label: 'Postres' },
   ];
 
   if (error) {
@@ -34,7 +34,7 @@ const Shop: React.FC = () => {
       <div className="min-h-screen bg-amber-50 py-12">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
-            <p className="text-red-600">Error loading products: {error}</p>
+            <p className="text-red-600">Error al cargar productos: {error}</p>
           </div>
         </div>
       </div>
@@ -46,9 +46,9 @@ const Shop: React.FC = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Header */}
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-gray-900 mb-4">Our Fresh Bakery</h1>
+          <h1 className="text-4xl font-bold text-gray-900 mb-4">Nuestra panadería</h1>
           <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Discover our selection of freshly baked breads, pastries, and desserts made with love and the finest ingredients.
+            Descubre nuestra selección de panes, pasteles y postres recién horneados con los mejores ingredientes.
           </p>
         </div>
 
@@ -57,7 +57,7 @@ const Shop: React.FC = () => {
           <div className="flex-1 relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5" />
             <Input
-              placeholder="Search products..."
+              placeholder="Buscar productos..."
               value={searchTerm}
               onChange={(e) => setSearchTerm(e.target.value)}
               className="pl-10"
@@ -103,7 +103,7 @@ const Shop: React.FC = () => {
           </div>
         ) : (
           <div className="text-center py-12">
-            <p className="text-gray-500 text-lg">No products found matching your criteria.</p>
+            <p className="text-gray-500 text-lg">No se encontraron productos que coincidan con tu búsqueda.</p>
           </div>
         )}
       </div>

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -32,6 +32,7 @@ export const useAuthStore = create<AuthState>()(
           
           // ▶▶▶ Fija el token en TU instancia "api", no en axios.defaults
           api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+          localStorage.setItem('token', token);
           
           
          set({ user, token, isLoading: false });
@@ -52,6 +53,7 @@ register: async (data: RegisterData) => {
           
           // ▶▶▶ Si tras registro quieres auto-login, fija también el header:
           api.defaults.headers.common['Authorization'] = `Bearer ${token}`;
+          localStorage.setItem('token', token);
 
           set({ user, token, isLoading: false });
         } catch (error: any) {
@@ -70,6 +72,7 @@ register: async (data: RegisterData) => {
         set({ user: null, token: null, error: null });
         // ▶▶▶ persist ya borra el storage; no hace falta removeItem manual
         // localStorage.removeItem('auth-storage');
+        localStorage.removeItem('token');
       },
 
       clearError: () => set({ error: null }),

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,12 +1,12 @@
 export const formatPrice = (price: number): string => {
-  return new Intl.NumberFormat('en-US', {
+  return new Intl.NumberFormat('es-ES', {
     style: 'currency',
     currency: 'USD',
   }).format(price);
 };
 
 export const formatDate = (date: string): string => {
-  return new Intl.DateTimeFormat('en-US', {
+  return new Intl.DateTimeFormat('es-ES', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
@@ -17,12 +17,12 @@ export const formatDate = (date: string): string => {
 
 export const formatOrderStatus = (status: string): string => {
   const statusMap: Record<string, string> = {
-    pending: 'Pending',
-    confirmed: 'Confirmed',
-    preparing: 'Preparing',
-    ready: 'Ready for Pickup',
-    delivered: 'Delivered',
-    cancelled: 'Cancelled',
+    pending: 'Pendiente',
+    confirmed: 'Confirmado',
+    preparing: 'Preparando',
+    ready: 'Listo para recoger',
+    delivered: 'Entregado',
+    cancelled: 'Cancelado',
   };
   return statusMap[status] || status;
 };


### PR DESCRIPTION
## Summary
- translate UI components and pages to Spanish
- persist auth token in localStorage so admin stays logged in
- localize price/date formatting

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd6ebfb948324b39898cd00ee3ef8