### PR TITLE
Improve payment flow

### DIFF
--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -1,11 +1,7 @@
 import axios from 'axios';
 
-console.log('🔎 [axiosConfig] baseURL =', import.meta.env.VITE_API_URL);
-
-const API_URL = import.meta.env.VITE_API_URL;
-if (!API_URL) {
-  throw new Error('VITE_API_URL no está definido');
-}
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+console.log('🔎 [axiosConfig] baseURL =', API_URL);
 
 const base = API_URL.replace(/\/$/, '');
 

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,3 +1,11 @@
+export interface CartItem {
+  id: string;
+  name: string;
+  imageUrl: string;
+  price: number;
+  quantity: number;
+}
+
 export interface OrderItem {
   id: number;
   productId: number;
@@ -12,6 +20,8 @@ export interface Order {
   total: number;
   status: string;
   createdAt: string;
+  paymentMethod: string;
+  cashAmount?: number;
   // ▶▶▶ Añade esto:
   OrderItems: OrderItem[];
   // Si usas customerInfo:
@@ -23,9 +33,20 @@ export interface Order {
 }
 
 export interface CheckoutData {
-  name: string;
-  email: string;
-  phone: string;
-  address: string;
-  paymentMethod: 'cash' | 'card';
+  items: {
+    productId: string | number;
+    quantity: number;
+    priceUnit: number;
+    subtotal: number;
+  }[];
+  paymentMethod: 'cash' | 'yape';
+  total: number;
+  cashAmount?: number;
+  customerId?: number;
+  customerInfo?: {
+    name: string;
+    email: string;
+    phone: string;
+    address: string;
+  };
 }


### PR DESCRIPTION
## Summary
- keep axios working even if `VITE_API_URL` is not defined
- extend order types
- update checkout to support Yape or cash with cash amount and send total

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684de031e2348324a8b050a6e268e647