### PR TITLE
Fix admin effect deps and add guest order support

### DIFF
--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -36,7 +36,7 @@ const OrderList: React.FC = () => {
     }
     // 3) Ya está todo validado: cargamos pedidos
     fetchOrders();
-  }, [user]);
+  }, [user, navigate]);
 
   const fetchOrders = async () => {
     try {

--- a/src/pages/Admin/ProductEdit.tsx
+++ b/src/pages/Admin/ProductEdit.tsx
@@ -24,7 +24,7 @@ const ProductEdit: React.FC = () => {
         .then(({ data }) => setForm(data))
         .catch((err) => console.error(err));
     }
-  }, [id]);
+  }, [id, isEdit]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -30,6 +30,14 @@ export interface Order {
     phone?: string;
     email?: string;
   };
+  // Para invitados, el backend puede devolver el Customer creado
+  Customer?: {
+    id: number;
+    name?: string;
+    phone?: string;
+    email?: string;
+    address?: string;
+  };
 }
 
 export interface CheckoutData {


### PR DESCRIPTION
## Summary
- fix React effect deps in admin pages to avoid warnings
- extend `Order` type with optional `Customer`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684de3cc6a3c8324a63c2b4c0a14a0d8