### PR TITLE
Adjust order types and checkout payload

### DIFF
--- a/src/pages/Admin/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard.tsx
@@ -81,7 +81,7 @@ const Dashboard: React.FC = () => {
                         Order #{order.id.slice(-8)}
                       </p>
                       <p className="text-sm text-gray-500">
-                        {order.customerInfo.name}
+                        {order.Customer?.name || 'Cliente'}
                       </p>
                     </div>
                     <div className="text-right">

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -10,10 +10,13 @@ import Button from '../../components/shared/Button';
 
 interface Order {
   id: number;
-  userId: number;
   total: number;
   status: string;
   createdAt: string;
+  Customer?: {
+    id: number;
+    name?: string;
+  };
 }
 
 const OrderList: React.FC = () => {
@@ -83,7 +86,9 @@ const OrderList: React.FC = () => {
                 {orders.map((o) => (
                   <tr key={o.id} className="border-t">
                     <td className="px-4 py-2">{o.id}</td>
-                    <td className="px-4 py-2">{o.userId}</td>
+                    <td className="px-4 py-2">
+                      {o.Customer?.name || o.Customer?.id || '—'}
+                    </td>
                     <td className="px-4 py-2">${o.total.toFixed(2)}</td>
                     <td className="px-4 py-2">{o.status}</td>
                     <td className="px-4 py-2">

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -122,13 +122,13 @@ const OrdersPage: React.FC = () => {
                         >
                           <div className="flex items-center space-x-3">
                             <img
-                              src={item.imageUrl}
-                              alt={item.name}
+                              src={item.Product.imageUrl}
+                              alt={item.Product.name}
                               className="h-10 w-10 object-cover rounded"
                             />
                             <div>
                               <p className="text-sm font-medium text-gray-900">
-                                {item.name}
+                                {item.Product.name}
                               </p>
                               <p className="text-xs text-gray-500">
                                 Cant: {item.quantity}

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -64,6 +64,12 @@ export const useOrderStore = create<OrderState>((set) => ({
           'guest_orders',
           JSON.stringify([resp.data, ...prev])
         );
+        if (resp.data.Customer && !localStorage.getItem('guest_customerId')) {
+          localStorage.setItem(
+            'guest_customerId',
+            String(resp.data.Customer.id)
+          );
+        }
       }
 
       return resp.data;

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -9,10 +9,13 @@ export interface CartItem {
 export interface OrderItem {
   id: number;
   productId: number;
-  name: string;
-  imageUrl: string;
   quantity: number;
   price: number;
+  Product: {
+    id: number;
+    name: string;
+    imageUrl: string;
+  };
 }
 
 export interface Order {
@@ -44,13 +47,9 @@ export interface CheckoutData {
   items: {
     productId: string | number;
     quantity: number;
-    priceUnit: number;
-    subtotal: number;
   }[];
   paymentMethod: 'cash' | 'yape';
-  total: number;
   cashAmount?: number;
-  customerId?: number;
   customerInfo?: {
     name: string;
     email: string;


### PR DESCRIPTION
## Summary
- update `OrderItem` and checkout types to new backend format
- store guest customer id after creating an order
- update checkout payload to only send required fields
- adjust order listing pages for new item structure

## Testing
- `npm run lint`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684de973d7048324b2770d9748ad34bc