### PR TITLE
Fix image URL handling in products

### DIFF
--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -28,7 +28,6 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
        <div className="relative overflow-hidden">
         <img
           src={resolveImageUrl(product.imageUrl)}
-          src={product.imageUrl}
           alt={product.name}
           className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
           onError={(e) => {

--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -147,7 +147,6 @@ const ProductForm: React.FC<ProductFormProps> = ({
           <div className="w-full h-48 border rounded-md overflow-hidden flex items-center justify-center bg-gray-50">
             <img
               src={resolveImageUrl(formData.imageUrl)}
-              src={formData.imageUrl}
               alt="Vista previa"
               className={`w-full h-full object-${previewFit}`}
               onError={(e) => {

--- a/src/pages/Admin/ProductEdit.tsx
+++ b/src/pages/Admin/ProductEdit.tsx
@@ -16,6 +16,7 @@ const ProductEdit: React.FC = () => {
     price: 0,
     stock: 0,
     description: '',
+    imageUrl: '',
   });
 
   useEffect(() => {
@@ -74,6 +75,13 @@ const ProductEdit: React.FC = () => {
           name="stock"
           type="number"
           value={form.stock}
+          onChange={handleChange}
+          required
+        />
+        <Input
+          label="URL de imagen"
+          name="imageUrl"
+          value={form.imageUrl}
           onChange={handleChange}
           required
         />


### PR DESCRIPTION
## Summary
- save product image URL in admin product edit page
- show product images properly by removing duplicate src attributes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e4f0a72d08324b63d9d7bb1ea64ce