### PR TITLE
Fix image URL persistence

### DIFF
--- a/src/api/productService.ts
+++ b/src/api/productService.ts
@@ -1,0 +1,29 @@
+import api from './axiosConfig';
+import { ProductFormData, Product } from '../types/product';
+
+export const fetchProduct = async (id: string): Promise<Product> => {
+  const { data } = await api.get(`/products/${id}`);
+  return data;
+};
+
+export const fetchProducts = async (): Promise<Product[]> => {
+  const { data } = await api.get('/products');
+  return data;
+};
+
+export const createProduct = async (data: ProductFormData): Promise<Product> => {
+  const { data: created } = await api.post('/products', data);
+  return created;
+};
+
+export const updateProduct = async (
+  id: string,
+  data: ProductFormData
+): Promise<Product> => {
+  const { data: updated } = await api.put(`/products/${id}`, data);
+  return updated;
+};
+
+export const deleteProduct = async (id: string): Promise<void> => {
+  await api.delete(`/products/${id}`);
+};

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -28,7 +28,6 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
        <div className="relative overflow-hidden">
         <img
           src={resolveImageUrl(product.imageUrl)}
-          src={product.imageUrl}
           alt={product.name}
           className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
           onError={(e) => {

--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -147,7 +147,6 @@ const ProductForm: React.FC<ProductFormProps> = ({
           <div className="w-full h-48 border rounded-md overflow-hidden flex items-center justify-center bg-gray-50">
             <img
               src={resolveImageUrl(formData.imageUrl)}
-              src={formData.imageUrl}
               alt="Vista previa"
               className={`w-full h-full object-${previewFit}`}
               onError={(e) => {

--- a/src/pages/Admin/ProductEdit.tsx
+++ b/src/pages/Admin/ProductEdit.tsx
@@ -2,7 +2,11 @@
 
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import api from '../../api/axiosConfig';
+import {
+  fetchProduct,
+  createProduct as createProductApi,
+  updateProduct as updateProductApi,
+} from '../../api/productService';
 import Input from '../../components/shared/Input';
 import Button from '../../components/shared/Button';
 
@@ -16,12 +20,13 @@ const ProductEdit: React.FC = () => {
     price: 0,
     stock: 0,
     description: '',
+    imageUrl: '',
   });
 
   useEffect(() => {
-    if (isEdit) {
-      api.get(`/products/${id}`)
-        .then(({ data }) => setForm(data))
+    if (isEdit && id) {
+      fetchProduct(id)
+        .then((data) => setForm(data))
         .catch((err) => console.error(err));
     }
   }, [id, isEdit]);
@@ -37,10 +42,10 @@ const ProductEdit: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      if (isEdit) {
-        await api.put(`/products/${id}`, form);
+      if (isEdit && id) {
+        await updateProductApi(id, form);
       } else {
-        await api.post('/products', form);
+        await createProductApi(form);
       }
       navigate('/admin/products');
     } catch (err) {
@@ -74,6 +79,13 @@ const ProductEdit: React.FC = () => {
           name="stock"
           type="number"
           value={form.stock}
+          onChange={handleChange}
+          required
+        />
+        <Input
+          label="URL de imagen"
+          name="imageUrl"
+          value={form.imageUrl}
           onChange={handleChange}
           required
         />

--- a/src/pages/Admin/ProductList.tsx
+++ b/src/pages/Admin/ProductList.tsx
@@ -2,7 +2,10 @@
 
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import api from '../../api/axiosConfig';
+import {
+  fetchProducts,
+  deleteProduct as deleteProductApi,
+} from '../../api/productService';
 import Button from '../../components/shared/Button';
 import { formatPrice } from '../../utils/formatters';
 
@@ -20,7 +23,7 @@ const ProductList: React.FC = () => {
   useEffect(() => {
     (async () => {
       try {
-        const { data } = await api.get<Product[]>('/products');
+        const data = await fetchProducts();
         setProducts(data);
       } catch (err) {
         console.error('Error cargando productos', err);
@@ -30,7 +33,7 @@ const ProductList: React.FC = () => {
 
   const handleDelete = async (id: number) => {
     if (!confirm('¿Seguro que quieres eliminar este producto?')) return;
-    await api.delete(`/products/${id}`);
+    await deleteProductApi(String(id));
     setProducts((prev) => prev.filter((p) => p.id !== id));
   };
 


### PR DESCRIPTION
## Summary
- add dedicated `productService` with update helpers
- use `productService` in admin product pages
- ensure `imageUrl` field is sent when editing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e4f0a72d08324b63d9d7bb1ea64ce