### PR TITLE
Fix order item totals and cleanup axios config

### DIFF
--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
-console.log('🔎 [axiosConfig] baseURL =', API_URL);
 
 const base = API_URL.replace(/\/$/, '');
 

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -142,7 +142,7 @@ const OrdersPage: React.FC = () => {
                             </div>
                           </div>
                           <p className="text-sm font-medium text-gray-900">
-                            {formatPrice(item.price * item.quantity)}
+                            {formatPrice(item.subtotal)}
                           </p>
                         </div>
                       ))}

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -10,7 +10,8 @@ export interface OrderItem {
   id: number;
   productId: number;
   quantity: number;
-  price: number;
+  priceUnit: number;
+  subtotal: number;
   Product: {
     id: number;
     name: string;


### PR DESCRIPTION
## Summary
- remove console debug from axios config
- use `priceUnit` and `subtotal` fields in `OrderItem`
- show each item subtotal in orders page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684eec4a83048324911fe040e0473fee