### PR TITLE
Fix image placeholder

### DIFF
--- a/src/assets/placeholder.svg
+++ b/src/assets/placeholder.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#e5e5e5" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="16" fill="#777">
+    Imagen no disponible
+  </text>
+</svg>

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -34,7 +34,6 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
           onError={(e) => {
             const target = e.currentTarget;
             target.onerror = null;
-            target.src = 'https://via.placeholder.com/300?text=Imagen+no+disponible';
             target.src = placeholderImg;
           }}
         />

--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -153,7 +153,6 @@ const ProductForm: React.FC<ProductFormProps> = ({
               onError={(e) => {
                 const target = e.currentTarget;
                 target.onerror = null;
-                target.src = 'https://via.placeholder.com/300?text=Imagen+no+disponible';
                 target.src = placeholderImg;
               }}
             />

--- a/src/pages/Admin/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard.tsx
@@ -121,7 +121,6 @@ const Dashboard: React.FC = () => {
                           onError={(e) => {
                             const target = e.currentTarget;
                             target.onerror = null;
-                            target.src = 'https://via.placeholder.com/100?text=Imagen';
                             target.src = placeholderImg;
                           }}
                         />

--- a/src/pages/Admin/Products.tsx
+++ b/src/pages/Admin/Products.tsx
@@ -196,7 +196,6 @@ const Products: React.FC = () => {
                             onError={(e) => {
                               const target = e.currentTarget;
                               target.onerror = null;
-                              target.src = 'https://via.placeholder.com/100?text=Imagen';
                               target.src = placeholderImg;
                             }}
                           />

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -54,7 +54,6 @@ const Cart: React.FC = () => {
                   onError={(e) => {
                     const target = e.currentTarget;
                     target.onerror = null;
-                    target.src = 'https://via.placeholder.com/100?text=Imagen';
                     target.src = placeholderImg;
                   }}
                 />

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -130,7 +130,6 @@ const OrdersPage: React.FC = () => {
                               onError={(e) => {
                                 const target = e.currentTarget;
                                 target.onerror = null;
-                                target.src = 'https://via.placeholder.com/100?text=Imagen';
                                 target.src = placeholderImg;
                               }}
                             />

--- a/src/utils/placeholder.ts
+++ b/src/utils/placeholder.ts
@@ -1,2 +1,2 @@
-const placeholderImage = 'https://via.placeholder.com/300?text=Imagen+no+disponible';
+import placeholderImage from '../assets/placeholder.svg';
 export default placeholderImage;


### PR DESCRIPTION
## Summary
- store a local placeholder image
- load placeholder asset when product images fail to load

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684eff2199d483249ab4c7d4e212a729