### PR TITLE
Fix default API base for images

### DIFF
--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_URL =
+  (import.meta.env.VITE_API_URL as string | undefined) ||
+  (typeof window !== 'undefined' ? window.location.origin : '');
 console.log('🔎 [axiosConfig] baseURL =', API_URL);
 
 const base = API_URL.replace(/\/$/, '');

--- a/src/utils/resolveImageUrl.ts
+++ b/src/utils/resolveImageUrl.ts
@@ -3,7 +3,9 @@ export function resolveImageUrl(url: string): string {
   if (/^https?:\/\//i.test(url)) {
     return url;
   }
-  const base = (import.meta.env.VITE_API_URL as string | undefined) || '';
+  const base =
+    (import.meta.env.VITE_API_URL as string | undefined) ||
+    (typeof window !== 'undefined' ? window.location.origin : '');
   if (!base) return url;
   const sanitizedBase = base.replace(/\/$/, '');
   const sanitizedUrl = url.replace(/^\//, '');


### PR DESCRIPTION
## Summary
- ensure axios resolves to the current origin when no API URL is set
- use the same logic when resolving image URLs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f1200a8148324a5d32942cee4eec0