### PR TITLE
Improve admin order management

### DIFF
--- a/src/utils/resolveImageUrl.ts
+++ b/src/utils/resolveImageUrl.ts
@@ -3,10 +3,12 @@ export function resolveImageUrl(url: string): string {
   if (/^https?:\/\//i.test(url)) {
     return url;
   }
-  const base =
+  let base =
+    (import.meta.env.VITE_ASSETS_URL as string | undefined) ||
     (import.meta.env.VITE_API_URL as string | undefined) ||
     (typeof window !== 'undefined' ? window.location.origin : '');
   if (!base) return url;
+  base = base.replace(/\/api\/?$/, '');
   const sanitizedBase = base.replace(/\/$/, '');
   const sanitizedUrl = url.replace(/^\//, '');
   return `${sanitizedBase}/${sanitizedUrl}`;


### PR DESCRIPTION
## Summary
- update `resolveImageUrl` to better handle backend base URL
- turn admin order list into a kanban board with status changes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f505f9d14832498ab69ecf4743b4b