### PR TITLE
Fix admin orders endpoint

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -13,7 +13,7 @@ export const ENDPOINTS = {
   customerOrders:   (clientId: string) => `/orders?clientId=${clientId}`,
 
   // Órdenes (admin)
-  adminOrders:     '/admin/orders',
+  adminOrders:     '/orders/all',
   
   // Gestión de productos (admin)
   adminProducts:   '/products',

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../../api/axiosConfig';
-import { ENDPOINTS } from '../../api/endpoints';
 import { useAuthStore } from '../../store/useAuthStore';
 import Button from '../../components/shared/Button';
 import {
@@ -49,7 +48,7 @@ const OrderList: React.FC = () => {
   const fetchOrders = async () => {
     try {
       setLoading(true);
-      const { data } = await api.get<Order[]>(ENDPOINTS.adminOrders);
+      const { data } = await api.get<Order[]>('/orders/all');
       setOrders(data);
     } catch (err: any) {
       console.error('Error fetching orders', err);
@@ -64,7 +63,7 @@ const OrderList: React.FC = () => {
     if (idx === -1 || idx === statuses.length - 1) return;
     const next = statuses[idx + 1];
     try {
-      await api.patch(`${ENDPOINTS.adminOrders}/${orderId}/status`, { status: next });
+      await api.patch(`/orders/${orderId}/status`, { status: next });
       setOrders((prev) =>
         prev.map((o) => (o.id === orderId ? { ...o, status: next } : o))
       );

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -85,9 +85,7 @@ export const useOrderStore = create<OrderState>((set) => ({
   updateOrderStatus: async (id, status) => {
     set({ isLoading: true, error: null });
     try {
-      const user = useAuthStore.getState().user;
-      const base = user?.role === 'admin' ? ENDPOINTS.adminOrders : ENDPOINTS.orders;
-      await api.patch(`${base}/${id}/status`, { status });
+      await api.patch(`${ENDPOINTS.orders}/${id}/status`, { status });
       set((st) => ({
         orders: st.orders.map(o =>
           o.id === id ? { ...o, status } : o


### PR DESCRIPTION
## Summary
- revert adminOrders endpoint
- fix admin order list page
- update updateOrderStatus function

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f7b77fd708324a468ea13d44df29e