### PR TITLE
Improve order admin view

### DIFF
--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -6,9 +6,11 @@ const API_URL =
 console.log('🔎 [axiosConfig] baseURL =', API_URL);
 
 const base = API_URL.replace(/\/$/, '');
+// Avoid duplicating the `/api` segment if provided in VITE_API_URL
+const apiBaseURL = base.endsWith('/api') ? base : `${base}/api`;
 
 const api = axios.create({
-  baseURL: `${base}/api`,
+  baseURL: apiBaseURL,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -73,6 +73,18 @@ const OrderList: React.FC = () => {
     }
   };
 
+  const cancelOrder = async (orderId: number) => {
+    try {
+      await api.patch(`/orders/${orderId}/status`, { status: 'cancelled' });
+      setOrders((prev) =>
+        prev.map((o) => (o.id === orderId ? { ...o, status: 'cancelled' } : o))
+      );
+    } catch (err: any) {
+      console.error('Error cancelling order', err);
+      setError(err.response?.data?.message || err.message);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -97,13 +109,26 @@ const OrderList: React.FC = () => {
                   {orders.filter((o) => o.status === st).map((o) => (
                     <div
                       key={o.id}
-                      className="bg-gray-50 rounded p-3 shadow border"
+                      className="bg-gray-50 rounded p-3 shadow border space-y-2"
                     >
                       <div className="text-sm font-medium">#{String(o.id).slice(-8)}</div>
                       <div className="text-xs text-gray-500">
-                        {o.Customer?.name || o.Customer?.id || '—'}
+                        {o.Customer?.name || o.customerInfo?.name || o.Customer?.id || '—'}
                       </div>
-                      <div className="text-sm font-semibold mb-2">
+                      <div className="text-xs text-gray-500">
+                        {o.Customer?.phone || o.customerInfo?.phone || '—'}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {o.Customer?.address || o.customerInfo?.address || '—'}
+                      </div>
+                      <ul className="text-xs text-gray-700 list-disc pl-4">
+                        {o.OrderItems.map(item => (
+                          <li key={item.id}>
+                            {item.Product.name} x {item.quantity}
+                          </li>
+                        ))}
+                      </ul>
+                      <div className="text-sm font-semibold">
                         {formatPrice(o.total)}
                       </div>
                       <div className="flex justify-between items-center">
@@ -112,13 +137,20 @@ const OrderList: React.FC = () => {
                         >
                           {formatOrderStatus(o.status)}
                         </span>
-                        <Button
-                          size="xs"
-                          onClick={() => advanceStatus(o.id, o.status)}
-                          disabled={o.status === 'delivered' || o.status === 'cancelled'}
-                        >
-                          Avanzar
-                        </Button>
+                        <div className="flex gap-2">
+                          {o.status === 'pending' && (
+                            <Button size="xs" variant="danger" onClick={() => cancelOrder(o.id)}>
+                              Rechazar
+                            </Button>
+                          )}
+                          <Button
+                            size="xs"
+                            onClick={() => advanceStatus(o.id, o.status)}
+                            disabled={o.status === 'delivered' || o.status === 'cancelled'}
+                          >
+                            Avanzar
+                          </Button>
+                        </div>
                       </div>
                     </div>
                   ))}

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import api from '../api/axiosConfig';
 import { ENDPOINTS } from '../api/endpoints';
 import { useAuthStore } from './useAuthStore';
+import { useProductStore } from './useProductStore';
 import type { Order, CheckoutData } from '../types/order';
 
 interface OrderState {
@@ -54,6 +55,13 @@ export const useOrderStore = create<OrderState>((set) => ({
         orders: [resp.data, ...st.orders],
         isLoading: false
       }));
+
+      // Update stock locally based on ordered items
+      const adjustStock = useProductStore.getState().adjustStock;
+      adjustStock(data.items.map(i => ({
+        productId: Number(i.productId),
+        quantity: i.quantity
+      })));
 
       // Si no hay usuario autenticado, persistir en localStorage
       const user = useAuthStore.getState().user;

--- a/src/store/useProductStore.ts
+++ b/src/store/useProductStore.ts
@@ -14,6 +14,7 @@ interface ProductState {
   createProduct: (data: ProductFormData) => Promise<void>;
   updateProduct: (id: string, data: ProductFormData) => Promise<void>;
   deleteProduct: (id: string) => Promise<void>;
+  adjustStock: (items: { productId: number; quantity: number }[]) => void;
   clearError: () => void;
 }
 
@@ -94,17 +95,26 @@ export const useProductStore = create<ProductState>((set) => ({
     set({ isLoading: true, error: null });
     try {
       await api.delete(ENDPOINTS.productById(id));
-      set(state => ({ 
+      set(state => ({
         products: state.products.filter(p => p.id !== id),
-        isLoading: false 
+        isLoading: false
       }));
     } catch (error: any) {
-      set({ 
+      set({
         error: error.response?.data?.message || 'Failed to delete product',
-        isLoading: false 
+        isLoading: false
       });
       throw error;
     }
+  },
+
+  adjustStock: (items) => {
+    set(state => ({
+      products: state.products.map(p => {
+        const item = items.find(i => String(i.productId) === String(p.id));
+        return item ? { ...p, stock: p.stock - item.quantity } : p;
+      })
+    }));
   },
 
   clearError: () => set({ error: null })


### PR DESCRIPTION
## Summary
- fix axios base URL when VITE_API_URL already contains `/api`
- add cancel order support and show order details in admin dashboard
- update product stock when creating an order

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f81d6cf9c8324bf3ef27a3a85a384