### PR TITLE
Add order deletion capability

### DIFF
--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -73,14 +73,13 @@ const OrderList: React.FC = () => {
     }
   };
 
-  const cancelOrder = async (orderId: number) => {
+  const deleteOrder = async (orderId: number) => {
+    if (!window.confirm('Eliminar la orden definitivamente?')) return;
     try {
-      await api.patch(`/orders/${orderId}/status`, { status: 'cancelled' });
-      setOrders((prev) =>
-        prev.map((o) => (o.id === orderId ? { ...o, status: 'cancelled' } : o))
-      );
+      await api.delete(`/orders/${orderId}`);
+      setOrders((prev) => prev.filter((o) => o.id !== orderId));
     } catch (err: any) {
-      console.error('Error cancelling order', err);
+      console.error('Error deleting order', err);
       setError(err.response?.data?.message || err.message);
     }
   };
@@ -139,7 +138,7 @@ const OrderList: React.FC = () => {
                         </span>
                         <div className="flex gap-2">
                           {o.status === 'pending' && (
-                            <Button size="xs" variant="danger" onClick={() => cancelOrder(o.id)}>
+                            <Button size="xs" variant="danger" onClick={() => deleteOrder(o.id)}>
                               Rechazar
                             </Button>
                           )}

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -18,7 +18,7 @@ import placeholderImg from '../utils/placeholder';
 const OrdersPage: React.FC = () => {
   const { user } = useAuthStore();
   const navigate = useNavigate();
-  const { orders, isLoading, error, fetchOrders } = useOrderStore();
+  const { orders, isLoading, error, fetchOrders, deleteOrder } = useOrderStore();
   const [guestOrders, setGuestOrders] = useState<typeof orders>([]);
   const location = useLocation();
   const [newOrder, setNewOrder] = useState<typeof orders[0] | null>(null);
@@ -53,6 +53,18 @@ const OrdersPage: React.FC = () => {
         return <XCircle className="h-5 w-5 text-red-500" />;
       default:
         return <Clock className="h-5 w-5 text-amber-500" />;
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!window.confirm('¿Cancelar este pedido?')) return;
+    try {
+      await deleteOrder(id);
+      if (!user) {
+        setGuestOrders(prev => prev.filter(o => o.id !== id));
+      }
+    } catch {
+      // Error handled in store
     }
   };
 
@@ -196,6 +208,17 @@ const OrdersPage: React.FC = () => {
                           </p>
                         </div>
                       </div>
+                    </div>
+                  )}
+                  {order.status === 'pending' && (
+                    <div className="mt-4">
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        onClick={() => handleDelete(order.id)}
+                      >
+                        Cancelar pedido
+                      </Button>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- allow deleting orders in store
- enable deleting/cancelling orders from admin order list
- let customers cancel their pending orders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f8a37edd08324a8207c29be4b6683