### PR TITLE
Add Yape payment instructions

### DIFF
--- a/src/assets/yape-qr.svg
+++ b/src/assets/yape-qr.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="300" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#e5e5e5" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="16" fill="#777">
+    Imagen no disponible
+  </text>
+</svg>

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -81,12 +81,6 @@ const Login: React.FC = () => {
           </Button>
         </form>
 
-        {/* Pie */}
-        <div className="text-center">
-          <p className="text-xs text-gray-500">
-            Credenciales de demo: admin@bakery.com / password
-          </p>
-        </div>
       </div>
     </div>
   );

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../store/useAuthStore';
 import { formatPrice } from '../utils/formatters';
 import Input from '../components/shared/Input';
 import Button from '../components/shared/Button';
+import yapeQr from '../assets/yape-qr.svg';
 
 interface FormData {
   name: string;
@@ -181,6 +182,20 @@ const Checkout: React.FC = () => {
                     onChange={handleChange}
                     required
                   />
+                )}
+                {formData.paymentMethod === 'yape' && (
+                  <div className="flex flex-col items-center">
+                    <img
+                      src={yapeQr}
+                      alt="QR Yape"
+                      className="w-40 h-40 object-cover mx-auto"
+                    />
+                    <p className="text-center text-sm text-gray-700 mt-2">
+                      Realiza tu pago al{' '}
+                      <span className="font-semibold">928527185</span> y envía la
+                      constancia a este mismo número.
+                    </p>
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- remove demo credentials text from login page
- show QR image and phone number when Yape is selected in checkout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684f97e3d3c88324a6b87b5cf29927eb