### PR TITLE
Fix orders page empty due to missing items

### DIFF
--- a/src/api/orderService.ts
+++ b/src/api/orderService.ts
@@ -3,10 +3,10 @@ import { ENDPOINTS } from './endpoints';
 import type { Order, OrderStatus, CheckoutData } from '../types/order';
 
 export const getOrders = () =>
-  api.get<Order[]>(`${ENDPOINTS.orders}?expand=customer`);
+  api.get<Order[]>(`${ENDPOINTS.orders}?expand=customer,items`);
 
 export const getOrderById = (id: string) =>
-  api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=customer`);
+  api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=customer,items`);
 
 export const createOrder = (data: CheckoutData) =>
   api.post<Order>(ENDPOINTS.orders, data);

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -42,7 +42,7 @@ const OrderList: React.FC = () => {
   const fetchOrders = async () => {
     try {
       setLoading(true);
-      const { data } = await api.get<Order[]>('/orders/all?expand=customer');
+      const { data } = await api.get<Order[]>('/orders/all?expand=customer,items');
       setOrders(data);
     } catch (err: any) {
       console.error('Error fetching orders', err);

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -43,7 +43,7 @@ export const useOrderStore = create<OrderState>((set) => ({
     try {
       const endpoint =
         user.role === 'admin' ? ENDPOINTS.adminOrders : ENDPOINTS.orders;
-      const resp = await api.get<Order[]>(`${endpoint}?expand=customer`);
+      const resp = await api.get<Order[]>(`${endpoint}?expand=customer,items`);
       set({ orders: resp.data, isLoading: false });
     } catch (err: any) {
       set({


### PR DESCRIPTION
## Summary
- request `items` relation when fetching orders
- fetch order items in order store and admin orders list

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68504e306c448324aacedf2ec0057817