### PR TITLE
Update order events with SSE

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import AdminSidebar from './components/Layout/AdminSidebar';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
@@ -88,6 +88,18 @@ const HomePage: React.FC = () => {
 };
 
 function App() {
+  // Subscribe to order update events via SSE
+  useEffect(() => {
+    const es = new EventSource('/api/orders/stream');
+    const handler = () => {
+      window.dispatchEvent(new CustomEvent('orders-updated'));
+    };
+    es.addEventListener('orders-updated', handler);
+    return () => {
+      es.removeEventListener('orders-updated', handler);
+      es.close();
+    };
+  }, []);
 
   return (
     <Router>

--- a/src/pages/Admin/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard.tsx
@@ -15,6 +15,12 @@ const Dashboard: React.FC = () => {
     fetchOrders();
   }, [fetchProducts, fetchOrders]);
 
+  useEffect(() => {
+    const handler = () => fetchOrders();
+    window.addEventListener('orders-updated', handler);
+    return () => window.removeEventListener('orders-updated', handler);
+  }, [fetchOrders]);
+
   const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);
   const pendingOrders = orders.filter(order => order.status === 'pending').length;
   const outOfStockProducts = products.filter(product => !product.inStock).length;

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -52,6 +52,12 @@ const OrderList: React.FC = () => {
     }
   };
 
+  useEffect(() => {
+    const handler = () => fetchOrders();
+    window.addEventListener('orders-updated', handler);
+    return () => window.removeEventListener('orders-updated', handler);
+  }, []);
+
   const advanceStatus = async (orderId: string, current: string) => {
     const idx = statuses.indexOf(current);
     if (idx === -1 || idx === statuses.length - 1) return;
@@ -60,7 +66,7 @@ const OrderList: React.FC = () => {
       await updateOrderStatus(orderId, next as Order['status']);
       await refreshStore();
       fetchOrders();
-      window.dispatchEvent(new CustomEvent('orders:updated'));
+      window.dispatchEvent(new CustomEvent('orders-updated'));
     } catch (err: any) {
       console.error('Error updating status', err);
       setError(err.response?.data?.message || err.message);
@@ -73,7 +79,7 @@ const OrderList: React.FC = () => {
       await updateOrderStatus(orderId, 'rejected');
       await refreshStore();
       fetchOrders();
-      window.dispatchEvent(new CustomEvent('orders:updated'));
+      window.dispatchEvent(new CustomEvent('orders-updated'));
     } catch (err: any) {
       console.error('Error rejecting order', err);
       setError(err.response?.data?.message || err.message);

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -35,8 +35,8 @@ const OrdersPage: React.FC = () => {
 
   useEffect(() => {
     const handler = () => fetchOrders();
-    window.addEventListener('orders:updated', handler);
-    return () => window.removeEventListener('orders:updated', handler);
+    window.addEventListener('orders-updated', handler);
+    return () => window.removeEventListener('orders-updated', handler);
   }, [fetchOrders]);
 
   useEffect(() => {

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -117,7 +117,7 @@ export const useOrderStore = create<OrderState>((set) => ({
         orders: st.orders.map(o => (o.id === id ? { ...o, status } : o)),
         isLoading: false
       }));
-      window.dispatchEvent(new CustomEvent('orders:updated'));
+      window.dispatchEvent(new CustomEvent('orders-updated'));
     } catch (err: any) {
       set({
         error: err.response?.data?.message || err.message,
@@ -144,7 +144,7 @@ export const useOrderStore = create<OrderState>((set) => ({
           JSON.stringify(prev.filter(o => o.id !== id))
         );
       }
-      window.dispatchEvent(new CustomEvent('orders:updated'));
+      window.dispatchEvent(new CustomEvent('orders-updated'));
     } catch (err: any) {
       set({
         error: err.response?.data?.message || err.message,


### PR DESCRIPTION
## Summary
- listen to order events from `/api/orders/stream`
- refresh orders on SSE message using `orders-updated` event name
- keep admin and customer pages in sync with new events

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685057d47c808324aa3c362f6994949a