### PR TITLE
Fix API base URL

### DIFF
--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 const API_URL =
   (import.meta.env.VITE_API_URL as string | undefined) ||
-  (typeof window !== 'undefined' ? window.location.origin : '');
+  'http://localhost:3000';
 console.log('🔎 [axiosConfig] baseURL =', API_URL);
 
 const base = API_URL.replace(/\/$/, '');


### PR DESCRIPTION
## Summary
- restore default backend URL fallback to `http://localhost:3000`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68505b7ec73c832493a84269692f3f9d