### PR TITLE
Add customer details and rejection reason to orders

### DIFF
--- a/src/api/orderService.ts
+++ b/src/api/orderService.ts
@@ -14,5 +14,8 @@ export const createOrder = (data: CheckoutData) =>
 export const deleteOrder = (id: string) =>
   api.delete(`${ENDPOINTS.orders}/${id}`);
 
-export const updateOrderStatus = (orderId: string, status: OrderStatus) =>
-  api.patch(`${ENDPOINTS.orders}/${orderId}`, { status });
+export const updateOrderStatus = (
+  orderId: string,
+  status: OrderStatus,
+  reason?: string
+) => api.patch(`${ENDPOINTS.orders}/${orderId}`, reason ? { status, reason } : { status });

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -20,7 +20,6 @@ const OrderList: React.FC = () => {
     orders,
     fetchOrders,
     updateOrderStatus,
-    deleteOrder,
     isLoading: loading,
     error,
   } = useOrderStore();
@@ -61,10 +60,10 @@ const OrderList: React.FC = () => {
   };
 
   const rejectOrder = async (orderId: string) => {
-    if (!window.confirm('¿Rechazar este pedido?')) return;
+    const reason = window.prompt('¿Rechazar este pedido? Indica la razón:');
+    if (reason === null) return;
     try {
-      await deleteOrder(orderId);
-      await updateOrderStatus(orderId, 'rejected');
+      await updateOrderStatus(orderId, 'rejected', reason);
       await fetchOrders();
       window.dispatchEvent(new CustomEvent('orders-updated'));
     } catch (err: any) {
@@ -112,6 +111,9 @@ const OrderList: React.FC = () => {
                         >
                           <WhatsAppIcon className="w-4 h-4 text-green-600" />
                         </a>
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {o.customer?.email || '—'}
                       </div>
                       <div className="text-xs text-gray-500">
                         {o.customer?.address || '—'}

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -210,17 +210,22 @@ const OrdersPage: React.FC = () => {
                             {order.customer.phone || '—'}
                           </p>
                           <p className="text-gray-600">
-                            {order.customer.email || '—'}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  )}
-                  {order.status === 'pending' && (
-                    <div className="mt-4">
-                      <Button
-                        size="sm"
-                        variant="danger"
+                  {order.customer.email || '—'}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+          {order.status === 'rejected' && order.reason && (
+            <div className="border-t border-gray-200 pt-4 mt-4">
+              <p className="text-sm text-red-600">Pedido rechazado: {order.reason}</p>
+            </div>
+          )}
+          {order.status === 'pending' && (
+            <div className="mt-4">
+              <Button
+                size="sm"
+                variant="danger"
                         onClick={() => handleDelete(order.id)}
                       >
                         Cancelar pedido

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -18,7 +18,11 @@ interface OrderState {
   error: string | null;
   fetchOrders: () => Promise<void>;
   createOrder: (data: CheckoutData) => Promise<Order>;
-  updateOrderStatus: (id: string, status: Order['status']) => Promise<void>;
+  updateOrderStatus: (
+    id: string,
+    status: Order['status'],
+    reason?: string
+  ) => Promise<void>;
   deleteOrder: (id: string) => Promise<void>;
   clearError: () => void;
 }
@@ -96,6 +100,8 @@ export const useOrderStore = create<OrderState>((set) => ({
         }
       }
 
+      window.dispatchEvent(new CustomEvent('orders-updated'));
+
       return order;
     } catch (err: any) {
       set({
@@ -106,12 +112,14 @@ export const useOrderStore = create<OrderState>((set) => ({
     }
   },
 
-  updateOrderStatus: async (id, status) => {
+  updateOrderStatus: async (id, status, reason?) => {
     set({ isLoading: true, error: null });
     try {
-      await apiUpdateStatus(id, status);
+      await apiUpdateStatus(id, status, reason);
       set((st) => ({
-        orders: st.orders.map(o => (o.id === id ? { ...o, status } : o)),
+        orders: st.orders.map(o =>
+          o.id === id ? { ...o, status, ...(reason ? { reason } : {}) } : o
+        ),
         isLoading: false
       }));
       window.dispatchEvent(new CustomEvent('orders-updated'));

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -45,6 +45,7 @@ export interface Order {
   total?: number;
   paymentMethod?: string;
   cashAmount?: number;
+  reason?: string;
 }
 
 export interface CheckoutData {

--- a/src/utils/mapApiOrder.ts
+++ b/src/utils/mapApiOrder.ts
@@ -30,5 +30,6 @@ export function mapApiOrder(apiOrder: any): Order {
     paymentMethod:
       apiOrder.paymentMethod ?? apiOrder.payment_method ?? undefined,
     cashAmount: apiOrder.cashAmount ?? apiOrder.cash_amount ?? undefined,
+    reason: apiOrder.reason ?? apiOrder.rejectionReason ?? apiOrder.rejection_reason ?? undefined,
   } as Order;
 }


### PR DESCRIPTION
## Summary
- display customer email in admin order cards
- notify order pages of new orders
- support rejection reasons when updating order status
- show rejection reason to customers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6850b7b11efc8324a1a9c18d30e506c4