### PR TITLE
Improve mobile cart access

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -100,17 +100,30 @@ const Header: React.FC = () => {
             )}
           </div>
 
-          {/* Mobile Menu Button */}
-          <button
-            onClick={toggleMobileMenu}
-            className="md:hidden p-2 rounded-md text-gray-700 hover:text-amber-600 focus:outline-none"
-          >
-            {isMobileMenuOpen ? (
-              <X className="h-6 w-6" />
-            ) : (
-              <Menu className="h-6 w-6" />
-            )}
-          </button>
+          {/* Mobile Actions */}
+          <div className="flex items-center space-x-4 md:hidden">
+            <Link
+              to="/cart"
+              className="relative p-2 text-gray-700 hover:text-amber-600 transition-colors duration-200"
+            >
+              <ShoppingCart className="h-6 w-6" />
+              {cartCount > 0 && (
+                <span className="absolute -top-1 -right-1 bg-amber-600 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
+                  {cartCount}
+                </span>
+              )}
+            </Link>
+            <button
+              onClick={toggleMobileMenu}
+              className="p-2 rounded-md text-gray-700 hover:text-amber-600 focus:outline-none"
+            >
+              {isMobileMenuOpen ? (
+                <X className="h-6 w-6" />
+              ) : (
+                <Menu className="h-6 w-6" />
+              )}
+            </button>
+          </div>
         </div>
 
         {/* Mobile Menu */}


### PR DESCRIPTION
## Summary
- show the cart icon beside the menu button on small screens
- keep mobile dropdown with login and orders

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850b8bde3e083249d18136bb637f076