### PR TITLE
Fix product category filtering and image URLs

### DIFF
--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Search } from 'lucide-react';
 import { useProductStore } from '../store/useProductStore';
 import ProductCard from '../components/Product/ProductCard';
@@ -14,20 +14,39 @@ const Shop: React.FC = () => {
   }, [fetchProducts]);
 
   const filteredProducts = products.filter(product => {
-    const matchesSearch = product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-                         product.description.toLowerCase().includes(searchTerm.toLowerCase());
-    const matchesCategory = selectedCategory === 'all' || product.category === selectedCategory;
+    const matchesSearch =
+      product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      product.description.toLowerCase().includes(searchTerm.toLowerCase());
+
+    const productCategory = product.category?.toLowerCase() || '';
+    const matchesCategory =
+      selectedCategory === 'all' || productCategory === selectedCategory;
+
     return matchesSearch && matchesCategory;
   });
 
-  const categories = [
-    { value: 'all', label: 'Todos' },
-    { value: 'bread', label: 'Pan' },
-    { value: 'pastry', label: 'Pasteles' },
-    { value: 'cake', label: 'Tortas' },
-    { value: 'cookie', label: 'Galletas' },
-    { value: 'dessert', label: 'Postres' },
-  ];
+  const categories = useMemo(() => {
+    const labelMap: Record<string, string> = {
+      bread: 'Pan',
+      pastry: 'Pasteles',
+      cake: 'Tortas',
+      cookie: 'Galletas',
+      dessert: 'Postres',
+    };
+
+    const unique = Array.from(
+      new Set(
+        products
+          .map(p => p.category?.toLowerCase())
+          .filter((c): c is string => Boolean(c))
+      )
+    );
+
+    return [
+      { value: 'all', label: 'Todos' },
+      ...unique.map(c => ({ value: c, label: labelMap[c] || c })),
+    ];
+  }, [products]);
 
   if (error) {
     return (

--- a/src/utils/resolveImageUrl.ts
+++ b/src/utils/resolveImageUrl.ts
@@ -1,3 +1,17 @@
 export function resolveImageUrl(url: string): string {
-  return url ?? '';
+  if (!url) return '';
+
+  const isAbsolute = /^(https?:)?\/\//i.test(url);
+  if (isAbsolute) {
+    return url;
+  }
+
+  const base =
+    (import.meta.env.VITE_API_URL as string | undefined) ||
+    'http://localhost:3000';
+
+  const normalizedBase = base.replace(/\/$/, '');
+  const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
+
+  return `${normalizedBase}${normalizedUrl}`;
 }


### PR DESCRIPTION
## Summary
- ensure image URLs work even when relative
- derive category filter options from products so edits are reflected

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850b9a6fa88832491131c7fb730d0a5