### PR TITLE
Improve order handling

### DIFF
--- a/src/api/orderService.ts
+++ b/src/api/orderService.ts
@@ -3,10 +3,10 @@ import { ENDPOINTS } from './endpoints';
 import type { Order, OrderStatus, CheckoutData } from '../types/order';
 
 export const getOrders = () =>
-  api.get<Order[]>(`${ENDPOINTS.orders}?expand=customer,items`);
+  api.get<Order[]>(`${ENDPOINTS.orders}?expand=customer`);
 
 export const getOrderById = (id: string) =>
-  api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=customer,items`);
+  api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=customer`);
 
 export const createOrder = (data: CheckoutData) =>
   api.post<Order>(ENDPOINTS.orders, data);

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -23,7 +23,7 @@ const OrderList: React.FC = () => {
     isLoading: loading,
     error,
   } = useOrderStore();
-  const statuses = ['pending', 'confirmed', 'preparing', 'ready', 'delivered', 'cancelled', 'rejected'];
+  const statuses = ['pending', 'received', 'delivered', 'cancelled', 'rejected'];
 
   useEffect(() => {
     // 1) Si no hay usuario, lo mandamos a login
@@ -85,7 +85,7 @@ const OrderList: React.FC = () => {
         {loading ? (
           <p>Cargando pedidos…</p>
         ) : (
-          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 xl:grid-cols-7">
             {statuses.map((st) => (
               <div key={st} className="bg-white rounded-lg p-4 shadow">
                 <h3 className="text-sm font-semibold text-center mb-2">
@@ -136,13 +136,13 @@ const OrderList: React.FC = () => {
                       <div className="text-sm font-semibold">
                         {formatPrice(o.total)}
                       </div>
-                      <div className="flex justify-between items-center">
+                      <div className="flex flex-col sm:flex-row justify-between items-center gap-2">
                         <span
                           className={`inline-flex px-2 py-0.5 text-xs rounded-full ${getStatusColor(o.status)}`}
                         >
                           {formatOrderStatus(o.status)}
                         </span>
-                        <div className="flex gap-2">
+                        <div className="flex gap-2 flex-wrap justify-center">
                           {o.status === 'pending' && (
                             <Button size="xs" variant="danger" onClick={() => rejectOrder(o.id)}>
                               Rechazar

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -50,7 +50,7 @@ export const useOrderStore = create<OrderState>((set) => ({
     try {
       const endpoint =
         user.role === 'admin' ? ENDPOINTS.adminOrders : ENDPOINTS.orders;
-      const resp = await api.get<Order[]>(`${endpoint}?expand=customer,items`);
+      const resp = await api.get<Order[]>(`${endpoint}?expand=customer`);
       set({ orders: resp.data.map(mapApiOrder), isLoading: false });
     } catch (err: any) {
       set({

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,5 +1,6 @@
 export type OrderStatus =
   | 'pending'
+  | 'received'
   | 'confirmed'
   | 'preparing'
   | 'ready'

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -19,6 +19,7 @@ export const formatDate = (date: string): string => {
 export const formatOrderStatus = (status: string): string => {
   const statusMap: Record<string, string> = {
     pending: 'Pendiente',
+    received: 'Recibido',
     confirmed: 'Confirmado',
     preparing: 'Preparando',
     ready: 'Listo para recoger',
@@ -32,6 +33,7 @@ export const formatOrderStatus = (status: string): string => {
 export const getStatusColor = (status: string): string => {
   const colorMap: Record<string, string> = {
     pending: 'bg-yellow-100 text-yellow-800',
+    received: 'bg-blue-100 text-blue-800',
     confirmed: 'bg-blue-100 text-blue-800',
     preparing: 'bg-orange-100 text-orange-800',
     ready: 'bg-green-100 text-green-800',


### PR DESCRIPTION
## Summary
- fetch orders with customer info only
- align UI order statuses with backend
- tweak admin order grid and layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850f30b8c44832498f624d5cf7b48e9