### PR TITLE
Remove login prompts for customers

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -94,7 +94,7 @@ const Header: React.FC = () => {
               <Link to="/login">
                 <Button variant="primary" size="sm" className="flex items-center space-x-1">
                   <User className="h-4 w-4" />
-                  <span>Iniciar sesión</span>
+                  <span>Acceso admin</span>
                 </Button>
               </Link>
             )}
@@ -188,7 +188,7 @@ const Header: React.FC = () => {
                   <Link to="/login" onClick={() => setIsMobileMenuOpen(false)}>
                     <Button variant="primary" size="sm" className="flex items-center space-x-1">
                       <User className="h-4 w-4" />
-                      <span>Iniciar sesión</span>
+                      <span>Acceso admin</span>
                     </Button>
                   </Link>
                 )}

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -44,6 +44,7 @@ const Login: React.FC = () => {
             <Cake className="h-12 w-12 text-amber-600" />
             <h2 className="text-2xl font-extrabold text-gray-900">Digital Bakery</h2>
           </Link>
+          <p className="text-center text-gray-600">Acceso solo para administradores</p>
         </div>
 
         {/* Formulario */}


### PR DESCRIPTION
## Summary
- rename Login button to *Acceso admin*
- clarify that Login page is only for admins

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6850f4e7fd8083249ff8a3d858f3eb3e