### PR TITLE
Fix guest orders refresh

### DIFF
--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -23,13 +23,16 @@ const OrdersPage: React.FC = () => {
   const [newOrder, setNewOrder] = useState<typeof orders[0] | null>(null);
 
   useEffect(() => {
-    if (user) {
-      fetchOrders();
-    } else {
-      // Carga los pedidos de invitado desde localStorage
-      const stored = JSON.parse(localStorage.getItem('guest_orders') || '[]');
-      setGuestOrders(stored);
-    }
+    const load = async () => {
+      await fetchOrders();
+      if (!user) {
+        // Carga los pedidos de invitado desde localStorage para reflejar
+        // la respuesta más reciente de la API o el respaldo local
+        const stored = JSON.parse(localStorage.getItem('guest_orders') || '[]');
+        setGuestOrders(stored);
+      }
+    };
+    load();
   }, [user, fetchOrders]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- refresh guest orders from API on Orders page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851c3c258108324b4dbec4cafb832e9