### PR TITLE
Implement user account and profile pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import Cart from './pages/Cart';
 import Checkout from './pages/Checkout';
 import Orders from './pages/Orders';
 import Login from './pages/Auth/Login';
+import Register from './pages/Auth/Register';
+import Profile from './pages/Profile';
 import Dashboard from './pages/Admin/Dashboard';
 import OrderList from './pages/Admin/OrderList';
 import { useAuthStore } from './store/useAuthStore';
@@ -115,6 +117,15 @@ function App() {
             <Route path="/shop" element={<Shop />} />
             <Route path="/cart" element={<Cart />} />
             <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route
+              path="/profile"
+              element={
+                <ProtectedRoute>
+                  <Profile />
+                </ProtectedRoute>
+              }
+            />
             
             {/* Checkout y Orders ya no requieren login */}
             <Route path="/checkout" element={<Checkout />} />

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -4,6 +4,9 @@ export const ENDPOINTS = {
   login:    '/auth/login',
   register: '/auth/register',
 
+  // Perfil de usuario
+  userProfile: '/users/profile',
+
   // Productos
   products:    '/products',
   productById: (id: string) => `/products/${id}`,

--- a/src/api/userService.ts
+++ b/src/api/userService.ts
@@ -1,0 +1,11 @@
+import api from './axiosConfig';
+import { ENDPOINTS } from './endpoints';
+import type { Customer } from '../types/order';
+
+export const getUserProfile = () => api.get<Customer>(ENDPOINTS.userProfile);
+
+export const updateUserProfile = (data: {
+  name: string;
+  phone: string;
+  address: string;
+}) => api.put<Customer>(ENDPOINTS.userProfile, data);

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -79,7 +79,9 @@ const Header: React.FC = () => {
             {/* User Menu */}
             {user ? (
               <div className="flex items-center space-x-2">
-                <span className="text-sm text-gray-700">Hola, {user.name}</span>
+                <Link to="/profile" className="text-sm text-gray-700 hover:text-amber-600">
+                  Hola, {user.name}
+                </Link>
                 <Button
                   variant="outline"
                   size="sm"
@@ -172,18 +174,27 @@ const Header: React.FC = () => {
                 </Link>
 
                 {user ? (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => {
-                      handleLogout();
-                      setIsMobileMenuOpen(false);
-                    }}
-                    className="flex items-center space-x-1"
-                  >
-                    <LogOut className="h-4 w-4" />
-                    <span>Salir</span>
-                  </Button>
+                  <div className="flex items-center space-x-2">
+                    <Link
+                      to="/profile"
+                      className="text-sm text-gray-700 hover:text-amber-600"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                    >
+                      Mi perfil
+                    </Link>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => {
+                        handleLogout();
+                        setIsMobileMenuOpen(false);
+                      }}
+                      className="flex items-center space-x-1"
+                    >
+                      <LogOut className="h-4 w-4" />
+                      <span>Salir</span>
+                    </Button>
+                  </div>
                 ) : (
                   <Link to="/login" onClick={() => setIsMobileMenuOpen(false)}>
                     <Button variant="primary" size="sm" className="flex items-center space-x-1">

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Cake, Eye, EyeOff } from 'lucide-react';
+import { useAuthStore } from '../../store/useAuthStore';
+import Input from '../../components/shared/Input';
+import Button from '../../components/shared/Button';
+
+const Register: React.FC = () => {
+  const navigate = useNavigate();
+  const { register, isLoading, error, clearError } = useAuthStore();
+
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    password: '',
+  });
+  const [showPassword, setShowPassword] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    clearError();
+    try {
+      await register(formData);
+      navigate('/orders', { replace: true });
+    } catch {
+      // error handled in store
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <div className="flex items-center justify-center space-x-2 mb-6">
+            <Cake className="h-12 w-12 text-amber-600" />
+            <h2 className="text-2xl font-extrabold text-gray-900">Crear cuenta</h2>
+          </div>
+        </div>
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <Input
+            label="Nombre"
+            value={formData.name}
+            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+            required
+          />
+          <Input
+            label="Correo"
+            type="email"
+            value={formData.email}
+            onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+            required
+          />
+          <Input
+            label="Contraseña"
+            type={showPassword ? 'text' : 'password'}
+            value={formData.password}
+            onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+            required
+            rightIcon={
+              <button type="button" onClick={() => setShowPassword((prev) => !prev)}>
+                {showPassword ? <EyeOff /> : <Eye />}
+              </button>
+            }
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <Button type="submit" loading={isLoading} size="lg" className="w-full">
+            Registrarse
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Register;

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useCartStore } from '../store/useCartStore';
 import { useOrderStore } from '../store/useOrderStore';
-import { useAuthStore } from '../store/useAuthStore';
 import { formatPrice } from '../utils/formatters';
 import Input from '../components/shared/Input';
 import Button from '../components/shared/Button';
@@ -18,7 +17,6 @@ interface FormData {
 }
 const Checkout: React.FC = () => {
   const navigate = useNavigate();
-  const { user } = useAuthStore();
   const { items, total, clearCart } = useCartStore();
   const { createOrder, error, isLoading } = useOrderStore();
 
@@ -64,14 +62,6 @@ const Checkout: React.FC = () => {
         ? { cashAmount: Number(formData.cashAmount || 0) }
         : {}),
     };
-    if (!user) {
-      payload.customerInfo = {
-        name: formData.name,
-        phone: formData.phone,
-        email: formData.email,
-        address: formData.address,
-      };
-    }
     payload.customerInfo = {
       name: formData.name,
       phone: formData.phone,

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState } from 'react';
+import { useProfileStore } from '../store/useProfileStore';
+import Input from '../components/shared/Input';
+import Button from '../components/shared/Button';
+
+const Profile: React.FC = () => {
+  const { profile, fetchProfile, updateProfile, isLoading, error, clearError } = useProfileStore();
+  const [formData, setFormData] = useState({ name: '', phone: '', address: '' });
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  useEffect(() => {
+    if (profile) {
+      setFormData({
+        name: profile.name || '',
+        phone: profile.phone || '',
+        address: profile.address || '',
+      });
+    }
+  }, [profile]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    clearError();
+    try {
+      await updateProfile(formData);
+      alert('Perfil actualizado');
+    } catch {
+      // error shown below
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-amber-50 py-8">
+      <div className="max-w-xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-6">Mi perfil</h1>
+        <form onSubmit={handleSubmit} className="space-y-4 bg-white p-6 rounded-lg shadow">
+          <Input
+            label="Nombre"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+            required
+          />
+          <Input
+            label="Teléfono"
+            name="phone"
+            value={formData.phone}
+            onChange={handleChange}
+            required
+          />
+          <div>
+            <label htmlFor="address" className="block text-sm font-medium text-gray-700 mb-1">Dirección</label>
+            <textarea
+              id="address"
+              name="address"
+              value={formData.address}
+              onChange={handleChange}
+              className="w-full border border-gray-300 px-3 py-2 rounded focus:outline-none focus:ring focus:border-blue-300"
+              required
+            />
+          </div>
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <Button type="submit" loading={isLoading} className="w-full">
+            Guardar cambios
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+import api from '../api/axiosConfig';
+import { ENDPOINTS } from '../api/endpoints';
+import type { Customer } from '../types/order';
+
+interface ProfileState {
+  profile: Customer | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchProfile: () => Promise<void>;
+  updateProfile: (data: { name: string; phone: string; address: string }) => Promise<void>;
+  clearError: () => void;
+}
+
+export const useProfileStore = create<ProfileState>((set) => ({
+  profile: null,
+  isLoading: false,
+  error: null,
+
+  fetchProfile: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const resp = await api.get<Customer>(ENDPOINTS.userProfile);
+      set({ profile: resp.data, isLoading: false });
+    } catch (err: any) {
+      set({
+        error: err.response?.data?.message || err.message,
+        isLoading: false,
+      });
+    }
+  },
+
+  updateProfile: async (data) => {
+    set({ isLoading: true, error: null });
+    try {
+      const resp = await api.put<Customer>(ENDPOINTS.userProfile, data);
+      set({ profile: resp.data, isLoading: false });
+    } catch (err: any) {
+      set({
+        error: err.response?.data?.message || err.message,
+        isLoading: false,
+      });
+      throw err;
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));


### PR DESCRIPTION
## Summary
- add Register page for new users
- support profile viewing/editing with new Profile page and store
- expose `/users/profile` endpoint helpers
- add routes for register and profile
- link profile from the header
- send customer info once when creating orders

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851d3a824e883249eb9ea0914367162