### PR TITLE
Create separate management view for orders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Register from './pages/Auth/Register';
 import Profile from './pages/Profile';
 import Dashboard from './pages/Admin/Dashboard';
 import OrderList from './pages/Admin/OrderList';
+import OrderManagement from './pages/Admin/OrderManagement';
 import { useAuthStore } from './store/useAuthStore';
 
 
@@ -157,6 +158,7 @@ function App() {
               <Route path="products/create" element={<ProductEdit />} />
               <Route path="products/edit/:id" element={<ProductEdit />} />
               <Route path="orders" element={<OrderList />} />
+              <Route path="manage-orders" element={<OrderManagement />} />
             </Route>
        </Routes>
         </main>

--- a/src/components/Layout/AdminSidebar.tsx
+++ b/src/components/Layout/AdminSidebar.tsx
@@ -29,6 +29,14 @@ const AdminSidebar: React.FC = () => (
     >
       Pedidos
     </NavLink>
+    <NavLink
+      to="/admin/manage-orders"
+      className={({ isActive }) =>
+        isActive ? 'block font-semibold text-amber-600' : 'block text-gray-700'
+      }
+    >
+      Gestionar pedidos
+    </NavLink>
     {/* …otros enlaces… */}
   </nav>
 );


### PR DESCRIPTION
## Summary
- create an `OrderManagement` admin page with horizontal layout
- remove status actions from `OrderList` and make it read only
- add link in the admin sidebar to the new management page
- expose the page under `/admin/manage-orders` route

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685212c61114832481ea637a54292064