### PR TITLE
Implement Spanish categories and bulk stock update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Header from './components/Layout/Header';
 import Products from './pages/Admin/Products';
 import ProductEdit from './pages/Admin/ProductEdit';
+import UpdateStock from './pages/Admin/UpdateStock';
 import ProtectedRoute from './components/Layout/ProtectedRoute';
 import Shop from './pages/Shop';
 import Cart from './pages/Cart';
@@ -14,6 +15,7 @@ import Login from './pages/Auth/Login';
 import Register from './pages/Auth/Register';
 import Profile from './pages/Profile';
 import Dashboard from './pages/Admin/Dashboard';
+import OrderList from './pages/Admin/OrderList';
 import OrderManagement from './pages/Admin/OrderManagement';
 import { useAuthStore } from './store/useAuthStore';
 
@@ -156,6 +158,8 @@ function App() {
               <Route path="products" element={<Products />} />
               <Route path="products/create" element={<ProductEdit />} />
               <Route path="products/edit/:id" element={<ProductEdit />} />
+              <Route path="update-stock" element={<UpdateStock />} />
+              <Route path="orders" element={<OrderList />} />
               <Route path="manage-orders" element={<OrderManagement />} />
             </Route>
        </Routes>

--- a/src/components/Layout/AdminSidebar.tsx
+++ b/src/components/Layout/AdminSidebar.tsx
@@ -22,6 +22,14 @@ const AdminSidebar: React.FC = () => (
       Productos
     </NavLink>
     <NavLink
+      to="/admin/orders"
+      className={({ isActive }) =>
+        isActive ? 'block font-semibold text-amber-600' : 'block text-gray-700'
+      }
+    >
+      Pedidos
+    </NavLink>
+    <NavLink
       to="/admin/manage-orders"
       className={({ isActive }) =>
         isActive ? 'block font-semibold text-amber-600' : 'block text-gray-700'

--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -92,6 +92,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
           label="Stock"
           name="stock"
           type="number"
+          min={0}
           value={formData.stock}
           onChange={handleInputChange}
           required

--- a/src/pages/Admin/OrderList.tsx
+++ b/src/pages/Admin/OrderList.tsx
@@ -1,26 +1,23 @@
-// src/pages/Admin/OrderManagement.tsx
+// src/pages/Admin/OrderList.tsx
 
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useOrderStore } from "../../store/useOrderStore";
 import { useAuthStore } from "../../store/useAuthStore";
-import Button from "../../components/shared/Button";
 import WhatsAppIcon from "../../components/shared/WhatsAppIcon";
 import {
   formatPrice,
   formatOrderStatus,
   getStatusColor,
 } from "../../utils/formatters";
-import type { Order } from "../../types/order";
 import { ORDER_STATUSES } from "../../types/order";
 
-const OrderManagement: React.FC = () => {
+const OrderList: React.FC = () => {
   const { user } = useAuthStore();
   const navigate = useNavigate();
   const {
     orders,
     fetchOrders,
-    updateOrderStatus,
     isLoading: loading,
     error,
   } = useOrderStore();
@@ -47,46 +44,14 @@ const OrderManagement: React.FC = () => {
     return () => window.removeEventListener("orders-updated", handler);
   }, [fetchOrders]);
 
-  const advanceStatus = async (orderId: string, current: string) => {
-    const idx = statuses.indexOf(current);
-    if (idx === -1 || idx === statuses.length - 1) return;
-    const next = statuses[idx + 1];
-    try {
-      await updateOrderStatus(orderId, next as Order["status"]);
-      await fetchOrders();
-      window.dispatchEvent(new CustomEvent("orders-updated"));
-    } catch (err: any) {
-      console.error("Error updating status", err);
-    }
-  };
-
-  const changeStatus = async (orderId: string, newStatus: Order["status"]) => {
-    try {
-      await updateOrderStatus(orderId, newStatus);
-      await fetchOrders();
-      window.dispatchEvent(new CustomEvent("orders-updated"));
-    } catch (err: any) {
-      console.error("Error updating status", err);
-    }
-  };
-
-  const rejectOrder = async (orderId: string) => {
-    const reason = window.prompt("¿Rechazar este pedido? Indica la razón:");
-    if (reason === null) return;
-    try {
-      await updateOrderStatus(orderId, "rejected", reason);
-      await fetchOrders();
-      window.dispatchEvent(new CustomEvent("orders-updated"));
-    } catch (err: any) {
-      console.error("Error rejecting order", err);
-    }
-  };
+  // Página de solo lectura: las acciones de cambio de estado
+  // se manejan en la vista de gestión
 
   return (
     <div className="min-h-screen bg-gray-50 py-8">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-8">
-          Gestión de Pedidos
+          Lista de Pedidos
         </h1>
 
         {error && (
@@ -100,7 +65,7 @@ const OrderManagement: React.FC = () => {
         {loading ? (
           <p>Cargando pedidos…</p>
         ) : (
-          <div className="flex gap-6 overflow-x-auto pb-4">
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 overflow-x-auto pb-4">
             {statuses.map((st) => (
               <div
                 key={st}
@@ -169,44 +134,6 @@ const OrderManagement: React.FC = () => {
                           >
                             {formatOrderStatus(o.status)}
                           </span>
-                          <div className="flex gap-2 flex-wrap justify-center">
-                            {o.status === "pending" && (
-                              <Button
-                                size="xs"
-                                variant="danger"
-                                onClick={() => rejectOrder(o.id)}
-                              >
-                                Rechazar
-                              </Button>
-                            )}
-                            <select
-                              className="text-xs border border-gray-300 rounded p-1"
-                              value={o.status}
-                              onChange={(e) =>
-                                changeStatus(
-                                  o.id,
-                                  e.target.value as Order["status"],
-                                )
-                              }
-                            >
-                              {ORDER_STATUSES.map((statusOpt) => (
-                                <option key={statusOpt} value={statusOpt}>
-                                  {formatOrderStatus(statusOpt)}
-                                </option>
-                              ))}
-                            </select>
-                            <Button
-                              size="xs"
-                              onClick={() => advanceStatus(o.id, o.status)}
-                              disabled={
-                                o.status === "delivered" ||
-                                o.status === "cancelled" ||
-                                o.status === "rejected"
-                              }
-                            >
-                              Avanzar
-                            </Button>
-                          </div>
                         </div>
                       </div>
                     ))}
@@ -220,4 +147,4 @@ const OrderManagement: React.FC = () => {
   );
 };
 
-export default OrderManagement;
+export default OrderList;

--- a/src/pages/Admin/ProductEdit.tsx
+++ b/src/pages/Admin/ProductEdit.tsx
@@ -87,6 +87,7 @@ const ProductEdit: React.FC = () => {
           label="Stock"
           name="stock"
           type="number"
+          min={0}
           value={form.stock}
           onChange={handleChange}
           required

--- a/src/pages/Admin/Products.tsx
+++ b/src/pages/Admin/Products.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Plus, Edit, Trash2, Search } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { useProductStore } from '../../store/useProductStore';
 import { Product, ProductFormData } from '../../types/product';
 import { formatPrice } from '../../utils/formatters';
@@ -18,6 +19,8 @@ const Products: React.FC = () => {
     isLoading,
     error,
   } = useProductStore();
+
+  const navigate = useNavigate();
 
   const [searchTerm, setSearchTerm] = useState('');
   const [showForm, setShowForm] = useState(false);
@@ -102,13 +105,21 @@ const Products: React.FC = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Gestión de Productos</h1>
-          <Button
-            onClick={() => setShowForm(true)}
-            className="flex items-center space-x-2"
-          >
-            <Plus className="h-5 w-5" />
-            <span>Agregar Producto</span>
-          </Button>
+          <div className="flex space-x-2">
+            <Button
+              onClick={() => setShowForm(true)}
+              className="flex items-center space-x-2"
+            >
+              <Plus className="h-5 w-5" />
+              <span>Agregar Producto</span>
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => navigate('/admin/update-stock')}
+            >
+              Actualizar Stock
+            </Button>
+          </div>
         </div>
 
         {error && (

--- a/src/pages/Admin/UpdateStock.tsx
+++ b/src/pages/Admin/UpdateStock.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useProductStore } from '../../store/useProductStore';
+import Button from '../../components/shared/Button';
+import Input from '../../components/shared/Input';
+import placeholderImg from '../../utils/placeholder';
+
+const UpdateStock: React.FC = () => {
+  const navigate = useNavigate();
+  const { products, fetchProducts, updateProduct, isLoading, error } = useProductStore();
+
+  const [stocks, setStocks] = useState<Record<string, number>>({});
+
+  useEffect(() => {
+    fetchProducts();
+  }, [fetchProducts]);
+
+  const handleChange = (id: string, value: string) => {
+    const num = Math.max(0, Number(value));
+    setStocks(prev => ({ ...prev, [id]: num }));
+  };
+
+  const handleSave = async (id: string) => {
+    const product = products.find(p => p.id === id);
+    if (!product) return;
+    const newStock = stocks[id];
+    if (newStock === undefined || newStock === product.stock) return;
+    try {
+      await updateProduct(id, { ...product, stock: newStock });
+    } catch {
+      // error handled by store
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Actualizar Stock</h1>
+          <Button variant="outline" onClick={() => navigate('/admin/products')}>Volver</Button>
+        </div>
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
+            <p className="text-sm text-red-600">{error}</p>
+          </div>
+        )}
+
+        <div className="bg-white rounded-lg shadow-md overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Producto
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Stock Actual
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Nuevo Stock
+                  </th>
+                  <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Acciones
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-gray-200">
+                {isLoading ? (
+                  [...Array(5)].map((_, index) => (
+                    <tr key={index} className="animate-pulse">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center">
+                          <div className="h-10 w-10 bg-gray-200 rounded"></div>
+                          <div className="ml-4">
+                            <div className="h-4 bg-gray-200 rounded w-32"></div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="h-4 bg-gray-200 rounded w-16"></div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="h-4 bg-gray-200 rounded w-16"></div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <div className="h-8 w-20 bg-gray-200 rounded"></div>
+                      </td>
+                    </tr>
+                  ))
+                ) : products.length > 0 ? (
+                  products.map(product => (
+                    <tr key={product.id} className="hover:bg-gray-50">
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <div className="flex items-center">
+                          <img
+                            className="h-10 w-10 rounded object-cover"
+                            src={product.imageUrl || placeholderImg}
+                            alt={product.name}
+                            onError={e => {
+                              const target = e.currentTarget;
+                              target.onerror = null;
+                              target.src = placeholderImg;
+                            }}
+                          />
+                          <div className="ml-4">
+                            <div className="text-sm font-medium text-gray-900">
+                              {product.name}
+                            </div>
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                        {product.stock}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <Input
+                          type="number"
+                          min={0}
+                          value={stocks[product.id] ?? product.stock}
+                          onChange={e => handleChange(product.id, e.target.value)}
+                          className="w-24"
+                        />
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                        <Button onClick={() => handleSave(product.id)} className="px-3 py-1">
+                          Guardar
+                        </Button>
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={4} className="px-6 py-4 text-center text-gray-500">
+                      No hay productos
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UpdateStock;

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -32,6 +32,9 @@ const Shop: React.FC = () => {
       cake: 'Tortas',
       cookie: 'Galletas',
       dessert: 'Postres',
+      general: 'General',
+      sweet: 'Dulces',
+      special: 'Especiales',
     };
 
     const unique = Array.from(


### PR DESCRIPTION
## Summary
- revert admin orders refactor
- translate shop categories to Spanish
- disallow negative stock values on forms
- add bulk stock update page in admin

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685260324670832491551169b61e8c9a