### PR TITLE
Implement new order statuses in admin panel

### DIFF
--- a/src/pages/Admin/OrderManagement.tsx
+++ b/src/pages/Admin/OrderManagement.tsx
@@ -30,7 +30,9 @@ const OrderManagement: React.FC = () => {
   const columnColors: Record<string, string> = {
     pending: "bg-yellow-50",
     received: "bg-blue-50",
-    delivered: "bg-green-50",
+    preparing: "bg-orange-50",
+    ready: "bg-green-50",
+    delivered: "bg-gray-50",
   };
 
   useEffect(() => {

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,7 +1,6 @@
 export type OrderStatus =
   | 'pending'
   | 'received'
-  | 'confirmed'
   | 'preparing'
   | 'ready'
   | 'delivered'
@@ -11,6 +10,8 @@ export type OrderStatus =
 export const ORDER_STATUSES: OrderStatus[] = [
   'pending',
   'received',
+  'preparing',
+  'ready',
   'delivered',
   'cancelled',
   'rejected',


### PR DESCRIPTION
## Summary
- add `preparing` and `ready` statuses to `ORDER_STATUSES`
- show new columns for these states in order management dashboard

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685325c2d01083249414a151f68b72ce