### PR TITLE
Fix order status update API endpoint

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -14,6 +14,7 @@ export const ENDPOINTS = {
   // Órdenes (cliente)
   orders:           '/orders',
   customerOrders:   (clientId: string) => `/orders?clientId=${clientId}`,
+  orderStatus:      (id: string) => `/orders/${id}/status`,
 
   // Órdenes (admin)
   adminOrders:     '/orders/all',

--- a/src/api/orderService.ts
+++ b/src/api/orderService.ts
@@ -21,4 +21,8 @@ export const updateOrderStatus = (
   orderId: string,
   status: OrderStatus,
   reason?: string
-) => api.patch(`${ENDPOINTS.orders}/${orderId}`, reason ? { status, reason } : { status });
+) =>
+  api.put(
+    `${ENDPOINTS.orderStatus(orderId)}`,
+    reason ? { status, reason } : { status }
+  );


### PR DESCRIPTION
## Summary
- update order status endpoint to `/orders/:id/status`
- add `orderStatus` helper in API endpoints

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68533b259ef08324af2db09cc6c1e1a6