### PR TITLE
Fix orders filtering

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -13,7 +13,7 @@ export const ENDPOINTS = {
 
   // Órdenes (cliente)
   orders:           '/orders',
-  customerOrders:   (clientId: string) => `/orders?clientId=${clientId}`,
+  customerOrders:   (customerId: string) => `/orders?customerId=${customerId}`,
   orderStatus:      (id: string) => `/orders/${id}/status`,
 
   // Órdenes (admin)


### PR DESCRIPTION
## Summary
- ensure endpoint uses `customerId` parameter
- fetch only the current customer's orders in the store

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685377ce178c832498b1334680f8f6a6