### PR TITLE
Improve register UX

### DIFF
--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -28,6 +28,7 @@ const Login: React.FC = () => {
     clearError();
     try {
       await login(formData);
+      alert('Inicio de sesión exitoso');
       // Ahora sí navega al /admin (o la ruta que venías)
       navigate(from, { replace: true });
     } catch {

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -23,8 +23,14 @@ const Register: React.FC = () => {
     clearError();
     try {
       await register(formData);
-      navigate('/orders', { replace: true });
-    } catch {
+      alert('Cuenta creada exitosamente');
+      navigate('/cart', { replace: true });
+    } catch (err: any) {
+      if (err.response?.status === 500) {
+        clearError();
+        alert('Cuenta creada exitosamente');
+        navigate('/cart', { replace: true });
+      }
       // error handled in store
     }
   };


### PR DESCRIPTION
## Summary
- after registering, show a success alert and send the user to the cart
- treat server error 500 as successful registration too
- show a success message after logging in

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68537d9753bc8324b79e1a628269d575