### PR TITLE
Actualizar checkout y órdenes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Shop from './pages/Shop';
 import Cart from './pages/Cart';
 import Checkout from './pages/Checkout';
 import Orders from './pages/Orders';
+import MyOrders from './pages/MyOrders';
 import Login from './pages/Auth/Login';
 import Register from './pages/Auth/Register';
 import Profile from './pages/Profile';
@@ -127,13 +128,27 @@ function App() {
               }
             />
             
-            {/* Checkout disponible sin iniciar sesión */}
-            <Route path="/checkout" element={<Checkout />} />
+            <Route
+              path="/checkout"
+              element={
+                <ProtectedRoute>
+                  <Checkout />
+                </ProtectedRoute>
+              }
+            />
             <Route
               path="/orders"
               element={
                 <ProtectedRoute>
                   <Orders />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/my-orders"
+              element={
+                <ProtectedRoute>
+                  <MyOrders />
                 </ProtectedRoute>
               }
             />

--- a/src/pages/MyOrders.tsx
+++ b/src/pages/MyOrders.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../store/useAuthStore';
+import { getOrdersByCustomer } from '../api/orderService';
+import { mapApiOrder } from '../utils/mapApiOrder';
+import type { Order } from '../types/order';
+import { formatPrice, formatDate, formatOrderStatus } from '../utils/formatters';
+
+const MyOrders: React.FC = () => {
+  const { user } = useAuthStore();
+  const navigate = useNavigate();
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/login', { replace: true });
+      return;
+    }
+    const fetchOrders = async () => {
+      try {
+        const resp = await getOrdersByCustomer(user.id);
+        setOrders(resp.data.map(mapApiOrder));
+      } catch (err: any) {
+        setError(err.response?.data?.message || err.message);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchOrders();
+  }, [user, navigate]);
+
+  if (loading) return <div>Cargando pedidos...</div>;
+  if (error) return <div>Error: {error}</div>;
+
+  return (
+    <div className="max-w-2xl mx-auto py-8">
+      <h1 className="text-2xl font-bold mb-4">Mis pedidos</h1>
+      <ul className="space-y-4">
+        {orders.map(order => (
+          <li key={order.id} className="border p-4 rounded">
+            <div className="flex justify-between">
+              <span>#{String(order.id).slice(-8)}</span>
+              <span>{formatDate(order.createdAt)}</span>
+            </div>
+            <div className="flex justify-between mt-2">
+              <span className="font-semibold">{formatPrice(order.total ?? 0)}</span>
+              <span>{formatOrderStatus(order.status)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default MyOrders;


### PR DESCRIPTION
## Summary
- remove localStorage usage from order store
- auto-fill Checkout form with profile information
- redirect Checkout to login when not authenticated
- add simple MyOrders page
- protect checkout route and add new route for MyOrders

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68538726e1408324b26d0faa71a55087