### PR TITLE
Improve profile page and checkout auto-fill

### DIFF
--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useCartStore } from '../store/useCartStore';
 import { useOrderStore } from '../store/useOrderStore';
 import { useAuthStore } from '../store/useAuthStore';
-import { getUserProfile } from '../api/userService';
+import { useProfileStore } from '../store/useProfileStore';
 import { formatPrice } from '../utils/formatters';
 import Input from '../components/shared/Input';
 import Button from '../components/shared/Button';
@@ -22,6 +22,7 @@ const Checkout: React.FC = () => {
   const { items, total, clearCart } = useCartStore();
   const { createOrder, error, isLoading } = useOrderStore();
   const { user } = useAuthStore();
+  const { profile, fetchProfile } = useProfileStore();
 
   useEffect(() => {
     if (!user) {
@@ -30,21 +31,25 @@ const Checkout: React.FC = () => {
     }
     const load = async () => {
       try {
-        const resp = await getUserProfile();
-        const info = resp.data;
-        setFormData(prev => ({
-          ...prev,
-          name: info.name || '',
-          phone: info.phone || '',
-          email: info.email || '',
-          address: info.address || '',
-        }));
+        if (!profile) {
+          await fetchProfile();
+        }
+        const info = useProfileStore.getState().profile;
+        if (info) {
+          setFormData(prev => ({
+            ...prev,
+            name: info.name || '',
+            phone: info.phone || '',
+            email: info.email || '',
+            address: info.address || '',
+          }));
+        }
       } catch {
         // ignore profile errors
       }
     };
     load();
-  }, [user, navigate]);
+  }, [user, navigate, profile, fetchProfile]);
 
   const [formData, setFormData] = useState<FormData>({
     name: '',

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useProfileStore } from '../store/useProfileStore';
 import Input from '../components/shared/Input';
 import Button from '../components/shared/Button';
@@ -71,6 +72,11 @@ const Profile: React.FC = () => {
           <Button type="submit" loading={isLoading} className="w-full">
             Guardar cambios
           </Button>
+          <Link to="/orders" className="block mt-4">
+            <Button type="button" variant="secondary" className="w-full">
+              Ver mis pedidos
+            </Button>
+          </Link>
         </form>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add link on profile page to easily access order history
- pre-fill checkout form with stored profile data

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68538d4a09088324a1cdcbe86b6412b6