### PR TITLE
Actualizar llamadas de órdenes

### DIFF
--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -12,9 +12,9 @@ export const ENDPOINTS = {
   productById: (id: string) => `/products/${id}`,
 
   // Órdenes (cliente)
-  orders:           '/orders',
-  customerOrders:   (customerId: string) => `/orders?userId=${customerId}`,
-  orderStatus:      (id: string) => `/orders/${id}/status`,
+  orders: '/orders',
+  userOrders: (userId: string) => `/orders?userId=${userId}`,
+  orderStatus: (id: string) => `/orders/${id}/status`,
 
   // Órdenes (admin)
   adminOrders:     '/orders/all',

--- a/src/api/orderService.ts
+++ b/src/api/orderService.ts
@@ -8,8 +8,8 @@ export const getOrders = () =>
 export const getOrderById = (id: string) =>
   api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=user`);
 
-export const getOrdersByCustomer = (customerId: string) =>
-  api.get<Order[]>(`${ENDPOINTS.customerOrders(customerId)}&expand=user`);
+export const getOrdersByUser = (userId: string) =>
+  api.get<Order[]>(`${ENDPOINTS.userOrders(userId)}&expand=user`);
 
 export const createOrder = (data: CheckoutData) =>
   api.post<Order>(ENDPOINTS.orders, data);

--- a/src/pages/MyOrders.tsx
+++ b/src/pages/MyOrders.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../store/useAuthStore';
-import { getOrdersByCustomer } from '../api/orderService';
+import { getOrdersByUser } from '../api/orderService';
 import { mapApiOrder } from '../utils/mapApiOrder';
 import type { Order } from '../types/order';
 import { formatPrice, formatDate, formatOrderStatus } from '../utils/formatters';
@@ -20,7 +20,7 @@ const MyOrders: React.FC = () => {
     }
     const fetchOrders = async () => {
       try {
-        const resp = await getOrdersByCustomer(user.id);
+        const resp = await getOrdersByUser(user.id);
         setOrders(resp.data.map(mapApiOrder));
       } catch (err: any) {
         setError(err.response?.data?.message || err.message);

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -6,7 +6,7 @@ import {
   updateOrderStatus as apiUpdateStatus,
   deleteOrder as apiDeleteOrder,
   getOrderById,
-  getOrdersByCustomer,
+  getOrdersByUser,
 } from '../api/orderService';
 import { useAuthStore } from './useAuthStore';
 import { useProductStore } from './useProductStore';
@@ -49,7 +49,7 @@ export const useOrderStore = create<OrderState>((set) => ({
         const resp = await api.get<Order[]>(`${ENDPOINTS.adminOrders}?expand=user`);
         set({ orders: resp.data.map(mapApiOrder), isLoading: false });
       } else {
-        const resp = await getOrdersByCustomer(user.id);
+        const resp = await getOrdersByUser(user.id);
         set({ orders: resp.data.map(mapApiOrder), isLoading: false });
       }
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- use `userOrders` endpoint for fetching user's orders
- rename API helpers to `getOrdersByUser`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685392f7280883248255cafeaced834c