### PR TITLE
Add email field to user profile

### DIFF
--- a/src/api/userService.ts
+++ b/src/api/userService.ts
@@ -6,6 +6,7 @@ export const getUserProfile = () => api.get<Customer>(ENDPOINTS.userProfile);
 
 export const updateUserProfile = (data: {
   name: string;
+  email: string;
   phone: string;
   address: string;
 }) => api.put<Customer>(ENDPOINTS.userProfile, data);

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -6,7 +6,12 @@ import Button from '../components/shared/Button';
 
 const Profile: React.FC = () => {
   const { profile, fetchProfile, updateProfile, isLoading, error, clearError } = useProfileStore();
-  const [formData, setFormData] = useState({ name: '', phone: '', address: '' });
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    phone: '',
+    address: '',
+  });
 
   useEffect(() => {
     fetchProfile();
@@ -16,6 +21,7 @@ const Profile: React.FC = () => {
     if (profile) {
       setFormData({
         name: profile.name || '',
+        email: profile.email || '',
         phone: profile.phone || '',
         address: profile.address || '',
       });
@@ -54,6 +60,14 @@ const Profile: React.FC = () => {
             label="Teléfono"
             name="phone"
             value={formData.phone}
+            onChange={handleChange}
+            required
+          />
+          <Input
+            label="Email"
+            name="email"
+            type="email"
+            value={formData.email}
             onChange={handleChange}
             required
           />

--- a/src/store/useProfileStore.ts
+++ b/src/store/useProfileStore.ts
@@ -8,7 +8,7 @@ interface ProfileState {
   isLoading: boolean;
   error: string | null;
   fetchProfile: () => Promise<void>;
-  updateProfile: (data: { name: string; phone: string; address: string }) => Promise<void>;
+  updateProfile: (data: { name: string; email: string; phone: string; address: string }) => Promise<void>;
   clearError: () => void;
 }
 


### PR DESCRIPTION
## Summary
- allow sending email when updating the user profile
- update profile store to handle email
- include editable email field in Profile page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853aa3003e08324bbb3960abc926bf9