### PR TITLE
Fix order customer data

### DIFF
--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -89,12 +89,22 @@ const Checkout: React.FC = () => {
       ...(formData.paymentMethod === 'cash'
         ? { cashAmount: Number(formData.cashAmount || 0) }
         : {}),
+      // Enviar la información de contacto tanto de manera anidada
+      // como en la raíz para maximizar compatibilidad con la API
+      name: formData.name,
+      email: formData.email,
+      phone: formData.phone,
+      address: formData.address,
     };
     payload.customerInfo = {
       name: formData.name,
       phone: formData.phone,
       email: formData.email,
       address: formData.address,
+      Name: formData.name,
+      Email: formData.email,
+      Phone: formData.phone,
+      Address: formData.address,
     };
 
  try {

--- a/src/utils/mapApiOrder.ts
+++ b/src/utils/mapApiOrder.ts
@@ -29,8 +29,25 @@ export function mapApiOrder(apiOrder: any): Order {
   const customer = customerRaw
     ? {
         ...customerRaw,
-        phone: customerRaw.phone ?? customerRaw.Phone ?? '',
-        address: customerRaw.address ?? customerRaw.Address ?? '',
+        name:
+          customerRaw.name ??
+          customerRaw.Name ??
+          customerRaw.fullName ??
+          customerRaw.full_name ??
+          '',
+        email: customerRaw.email ?? customerRaw.Email ?? '',
+        phone:
+          customerRaw.phone ??
+          customerRaw.Phone ??
+          customerRaw.phoneNumber ??
+          customerRaw.phone_number ??
+          '',
+        address:
+          customerRaw.address ??
+          customerRaw.Address ??
+          customerRaw.addressLine ??
+          customerRaw.address_line ??
+          '',
         role: customerRaw.role ?? customerRaw.Role,
         createdAt: customerRaw.createdAt ?? customerRaw.created_at,
         updatedAt: customerRaw.updatedAt ?? customerRaw.updated_at,


### PR DESCRIPTION
## Summary
- include customer's info at root of order payload
- add synonyms when mapping API orders to handle varied field names

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853b2cce1408324b71b4189782f5e61