### PR TITLE
Fix customer info in orders

### DIFF
--- a/src/pages/Admin/OrderManagement.tsx
+++ b/src/pages/Admin/OrderManagement.tsx
@@ -136,6 +136,9 @@ const OrderManagement: React.FC = () => {
                         <div className="text-sm font-medium">
                           #{String(o.id).slice(-8)}
                         </div>
+                        <div className="text-xs text-gray-400">
+                          {formatDate(o.createdAt)}
+                        </div>
                         <div className="text-xs text-gray-500">
                           {o.customer?.name || o.customer?.id || "—"}
                         </div>

--- a/src/utils/mapApiOrder.ts
+++ b/src/utils/mapApiOrder.ts
@@ -26,7 +26,8 @@ export function mapApiOrder(apiOrder: any): Order {
     apiOrder.customerInfo ??
     apiOrder.CustomerInfo ??
     null;
-  const customer = customerRaw
+
+  let customer = customerRaw
     ? {
         ...customerRaw,
         name:
@@ -52,7 +53,34 @@ export function mapApiOrder(apiOrder: any): Order {
         createdAt: customerRaw.createdAt ?? customerRaw.created_at,
         updatedAt: customerRaw.updatedAt ?? customerRaw.updated_at,
       }
-    : customerRaw;
+    : ({} as any);
+
+  // If some fields are missing, try root-level aliases
+  customer = {
+    ...customer,
+    name:
+      customer.name ??
+      apiOrder.name ??
+      apiOrder.Name ??
+      apiOrder.fullName ??
+      apiOrder.full_name ??
+      '',
+    email: customer.email ?? apiOrder.email ?? apiOrder.Email ?? '',
+    phone:
+      customer.phone ??
+      apiOrder.phone ??
+      apiOrder.Phone ??
+      apiOrder.phoneNumber ??
+      apiOrder.phone_number ??
+      '',
+    address:
+      customer.address ??
+      apiOrder.address ??
+      apiOrder.Address ??
+      apiOrder.addressLine ??
+      apiOrder.address_line ??
+      '',
+  };
 
   const createdAt = apiOrder.createdAt ?? apiOrder.created_at ?? '';
 


### PR DESCRIPTION
## Summary
- make order mapping grab fallback fields on root object
- display order date in admin order management

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853b4e4b91c8324ab0a36589d1d4756