### PR TITLE
Fix order card data completeness

### DIFF
--- a/src/components/shared/PaymentMethodIcon.tsx
+++ b/src/components/shared/PaymentMethodIcon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { QrCode, Banknote } from 'lucide-react';
+
+interface PaymentMethodIconProps extends React.SVGProps<SVGSVGElement> {
+  method: string | undefined;
+}
+
+const PaymentMethodIcon: React.FC<PaymentMethodIconProps> = ({ method, ...props }) => {
+  if (method === 'yape') return <QrCode {...props} />;
+  if (method === 'cash') return <Banknote {...props} />;
+  return null;
+};
+
+export default PaymentMethodIcon;

--- a/src/pages/Admin/OrderManagement.tsx
+++ b/src/pages/Admin/OrderManagement.tsx
@@ -6,11 +6,13 @@ import { useOrderStore } from "../../store/useOrderStore";
 import { useAuthStore } from "../../store/useAuthStore";
 import Button from "../../components/shared/Button";
 import WhatsAppIcon from "../../components/shared/WhatsAppIcon";
+import PaymentMethodIcon from "../../components/shared/PaymentMethodIcon";
 import {
   formatPrice,
   formatDate,
   formatOrderStatus,
   getStatusColor,
+  formatPaymentMethod,
 } from "../../utils/formatters";
 import type { Order } from "../../types/order";
 import { ORDER_STATUSES } from "../../types/order";
@@ -161,11 +163,17 @@ const OrderManagement: React.FC = () => {
                           {o.customer?.address || "—"}
                         </div>
                         {o.paymentMethod && (
-                          <div className="text-xs text-gray-500">
-                            Pago: {o.paymentMethod}
-                            {o.paymentMethod === "cash" && o.cashAmount
-                              ? ` (S/ ${o.cashAmount})`
-                              : ""}
+                          <div className="flex items-center gap-1 text-xs text-gray-500">
+                            <PaymentMethodIcon
+                              method={o.paymentMethod}
+                              className="w-4 h-4 inline"
+                            />
+                            <span>
+                              Pago: {formatPaymentMethod(o.paymentMethod)}
+                              {o.paymentMethod === "cash" && o.cashAmount
+                                ? ` (S/ ${o.cashAmount})`
+                                : ""}
+                            </span>
                           </div>
                         )}
                         <ul className="text-xs text-gray-700 list-disc pl-4">

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -43,3 +43,10 @@ export const getStatusColor = (status: string): string => {
   };
   return colorMap[status] || 'bg-gray-100 text-gray-800';
 };
+export const formatPaymentMethod = (method: string): string => {
+  const map: Record<string, string> = {
+    yape: 'Yape',
+    cash: 'Efectivo',
+  };
+  return map[method] || method;
+};


### PR DESCRIPTION
## Summary
- add PaymentMethodIcon to show payment icons
- add `formatPaymentMethod` formatter
- display formatted payment method with icon in admin order cards

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68543ec1f9cc8324bb57b972877a32e5