### PR TITLE
Fix admin revenue calculation

### DIFF
--- a/src/pages/Admin/Dashboard.tsx
+++ b/src/pages/Admin/Dashboard.tsx
@@ -20,7 +20,9 @@ const Dashboard: React.FC = () => {
     return () => window.removeEventListener('orders-updated', handler);
   }, [fetchOrders]);
 
-  const totalRevenue = orders.reduce((sum, order) => sum + order.total, 0);
+  const totalRevenue = orders
+    .filter((order) => order.status === 'delivered')
+    .reduce((sum, order) => sum + (order.total ?? 0), 0);
   const pendingOrders = orders.filter(order => order.status === 'pending').length;
   const outOfStockProducts = products.filter(product => !product.inStock).length;
 


### PR DESCRIPTION
## Summary
- compute revenue only from delivered orders

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68543fdf35c88324a6ebea8b03690782