### PR TITLE
Improve cart layout and add animation

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -68,7 +68,7 @@ const Header: React.FC = () => {
               to="/cart"
               className="relative p-2 text-gray-700 hover:text-amber-600 transition-colors duration-200"
             >
-              <ShoppingCart className="h-6 w-6" />
+              <ShoppingCart id="cart-icon" className="h-6 w-6" />
               {cartCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-amber-600 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
                   {cartCount}
@@ -108,7 +108,7 @@ const Header: React.FC = () => {
               to="/cart"
               className="relative p-2 text-gray-700 hover:text-amber-600 transition-colors duration-200"
             >
-              <ShoppingCart className="h-6 w-6" />
+              <ShoppingCart id="cart-icon-mobile" className="h-6 w-6" />
               {cartCount > 0 && (
                 <span className="absolute -top-1 -right-1 bg-amber-600 text-white text-xs rounded-full h-5 w-5 flex items-center justify-center">
                   {cartCount}
@@ -169,7 +169,7 @@ const Header: React.FC = () => {
                   className="flex items-center space-x-2 text-gray-700 hover:text-amber-600 transition-colors duration-200"
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
-                  <ShoppingCart className="h-5 w-5" />
+                  <ShoppingCart id="cart-icon-menu" className="h-5 w-5" />
                   <span>Carrito ({cartCount})</span>
                 </Link>
 

--- a/src/components/Product/ProductCard.tsx
+++ b/src/components/Product/ProductCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { Plus} from 'lucide-react';
 import { Product } from '../../types/product';
 import { useCartStore } from '../../store/useCartStore';
@@ -12,6 +12,7 @@ import placeholderImg from '../../utils/placeholder';
 
 const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
    const { addItem } = useCartStore();
+   const imgRef = useRef<HTMLImageElement>(null);
 
   const handleAddToCart = () => {
       addItem({
@@ -21,12 +22,49 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
         imageUrl: product.imageUrl,
         price: product.price,
       });
+
+      const img = imgRef.current;
+      const cartIcon =
+        document.getElementById('cart-icon') ||
+        document.getElementById('cart-icon-mobile') ||
+        document.getElementById('cart-icon-menu');
+
+      if (img && cartIcon) {
+        const imgRect = img.getBoundingClientRect();
+        const cartRect = cartIcon.getBoundingClientRect();
+
+        const clone = img.cloneNode(true) as HTMLImageElement;
+        clone.style.position = 'fixed';
+        clone.style.left = `${imgRect.left}px`;
+        clone.style.top = `${imgRect.top}px`;
+        clone.style.width = `${imgRect.width}px`;
+        clone.style.height = `${imgRect.height}px`;
+        clone.style.transition = 'transform 0.7s ease-in-out, opacity 0.7s';
+        clone.style.zIndex = '50';
+        clone.style.pointerEvents = 'none';
+        document.body.appendChild(clone);
+
+        const translateX =
+          cartRect.left + cartRect.width / 2 - (imgRect.left + imgRect.width / 2);
+        const translateY =
+          cartRect.top + cartRect.height / 2 - (imgRect.top + imgRect.height / 2);
+
+        requestAnimationFrame(() => {
+          clone.style.transform = `translate(${translateX}px, ${translateY}px) scale(0.1)`;
+          clone.style.opacity = '0';
+        });
+
+        clone.addEventListener('transitionend', () => {
+          clone.remove();
+        });
+      }
    };
 
   return (
      <div className="bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 overflow-hidden group">
        <div className="relative overflow-hidden">
         <img
+          ref={imgRef}
           src={product.imageUrl || placeholderImg}
           alt={product.name}
           className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -45,7 +45,10 @@ const Cart: React.FC = () => {
         <div className="bg-white rounded-lg shadow-md overflow-hidden">
           <div className="divide-y divide-gray-200">
             {items.map((item) => (
-              <div key={item.id} className="p-6 flex items-center space-x-4">
+              <div
+                key={item.id}
+                className="p-4 sm:p-6 grid grid-cols-[auto_1fr_auto] sm:grid-cols-[auto_1fr_auto_auto_auto] gap-4 items-center"
+              >
                 <img
                   src={item.imageUrl || placeholderImg}
                   alt={item.name}
@@ -57,7 +60,7 @@ const Cart: React.FC = () => {
                   }}
                 />
                 
-                <div className="flex-1 min-w-0">
+                <div className="min-w-0">
                   <h3 className="text-lg font-medium text-gray-900">{item.name}</h3>
                   <p className="text-lg font-semibold text-amber-600">
                     {formatPrice(item.price)}
@@ -85,7 +88,7 @@ const Cart: React.FC = () => {
                   </button>
                 </div>
 
-                <div className="text-right">
+                <div className="text-right col-span-2 sm:col-auto">
                   <p className="text-lg font-semibold text-gray-900">
                     {formatPrice(item.price * item.quantity)}
                   </p>
@@ -93,7 +96,7 @@ const Cart: React.FC = () => {
 
                 <button
                   onClick={() => removeItem(item.id)}
-                  className="p-2 text-red-600 hover:bg-red-50 rounded-full transition-colors"
+                  className="p-2 text-red-600 hover:bg-red-50 rounded-full transition-colors justify-self-end"
                 >
                   <Trash2 className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
## Summary
- enhance cart layout on small screens so quantity and price don't overlap
- tag cart icons in the header for animations
- animate product image flying to cart when adding

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854abb835f08324840bf9496307baab