### PR TITLE
Fix admin order customer data

### DIFF
--- a/src/utils/mapApiOrder.ts
+++ b/src/utils/mapApiOrder.ts
@@ -23,6 +23,7 @@ export function mapApiOrder(apiOrder: any): Order {
     apiOrder.customer ??
     apiOrder.Customer ??
     apiOrder.User ??
+    apiOrder.user ??
     apiOrder.customerInfo ??
     apiOrder.CustomerInfo ??
     apiOrder.customer_info ??


### PR DESCRIPTION
## Summary
- include `user` alias in `mapApiOrder` so admin order cards can display phone numbers and addresses

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ab4f41778832499353136854f5e87