### PR TITLE
Fix admin order customer data

### DIFF
--- a/src/api/orderService.ts
+++ b/src/api/orderService.ts
@@ -3,13 +3,13 @@ import { ENDPOINTS } from './endpoints';
 import type { Order, OrderStatus, CheckoutData } from '../types/order';
 
 export const getOrders = () =>
-  api.get<Order[]>(`${ENDPOINTS.orders}?expand=user`);
+  api.get<Order[]>(`${ENDPOINTS.orders}?expand=user,customerInfo`);
 
 export const getOrderById = (id: string) =>
-  api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=user`);
+  api.get<Order>(`${ENDPOINTS.orders}/${id}?expand=user,customerInfo`);
 
 export const getOrdersByUser = (userId: string) =>
-  api.get<Order[]>(`${ENDPOINTS.userOrders(userId)}&expand=user`);
+  api.get<Order[]>(`${ENDPOINTS.userOrders(userId)}&expand=user,customerInfo`);
 
 export const createOrder = (data: CheckoutData) =>
   api.post<Order>(ENDPOINTS.orders, data);

--- a/src/store/useOrderStore.ts
+++ b/src/store/useOrderStore.ts
@@ -44,19 +44,35 @@ export const useOrderStore = create<OrderState>((set) => ({
 
 
    // Usuario autenticado → llamo al backend
-    try {
-      if (user.role === 'admin') {
-        const resp = await api.get<Order[]>(`${ENDPOINTS.adminOrders}?expand=user`);
-        set({ orders: resp.data.map(mapApiOrder), isLoading: false });
-      } else {
-        const resp = await getOrdersByUser(user.id);
-        set({ orders: resp.data.map(mapApiOrder), isLoading: false });
-      }
-    } catch (err: any) {
-      set({
-        error: err.response?.data?.message || err.message,
-        isLoading: false
-      });
+      try {
+        let ordersResp: Order[] = [];
+        if (user.role === 'admin') {
+          const resp = await api.get<Order[]>(`${ENDPOINTS.adminOrders}?expand=user,customerInfo`);
+          ordersResp = resp.data;
+        } else {
+          const resp = await getOrdersByUser(user.id);
+          ordersResp = resp.data;
+        }
+        let orders = ordersResp.map(mapApiOrder);
+        orders = await Promise.all(
+          orders.map(async (o) => {
+            if (!o.customer?.phone || !o.customer?.address) {
+              try {
+                const full = await getOrderById(o.id);
+                return mapApiOrder(full.data);
+              } catch {
+                return o;
+              }
+            }
+            return o;
+          })
+        );
+        set({ orders, isLoading: false });
+      } catch (err: any) {
+        set({
+          error: err.response?.data?.message || err.message,
+          isLoading: false
+        });
     }
   },
 

--- a/src/utils/mapApiOrder.ts
+++ b/src/utils/mapApiOrder.ts
@@ -23,6 +23,7 @@ export function mapApiOrder(apiOrder: any): Order {
     apiOrder.customer ??
     apiOrder.Customer ??
     apiOrder.User ??
+    apiOrder.user ??
     apiOrder.customerInfo ??
     apiOrder.CustomerInfo ??
     apiOrder.customer_info ??


### PR DESCRIPTION
## Summary
- include `customerInfo` expansion when fetching orders
- fetch full order details if phone or address is missing so admin cards display everything

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ab4f41778832499353136854f5e87