### PR TITLE
Add stock editor and simplify product form

### DIFF
--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -28,31 +28,9 @@ const ProductForm: React.FC<ProductFormProps> = ({
     allergens: initialData?.allergens || [],
   });
 
-  const [ingredientsText, setIngredientsText] = useState(
-    initialData?.ingredients?.join(', ') || ''
-  );
-  const [allergensText, setAllergensText] = useState(
-    initialData?.allergens?.join(', ') || ''
-  );
-
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    
-    const ingredients = ingredientsText
-      .split(',')
-      .map(item => item.trim())
-      .filter(item => item.length > 0);
-    
-    const allergens = allergensText
-      .split(',')
-      .map(item => item.trim())
-      .filter(item => item.length > 0);
-
-    await onSubmit({
-      ...formData,
-      ingredients,
-      allergens,
-    });
+    await onSubmit(formData);
   };
 
   const handleInputChange = (
@@ -154,21 +132,6 @@ const ProductForm: React.FC<ProductFormProps> = ({
           />
         </>
       )}
-
-
-      <Input
-        label="Ingredientes (separados por coma)"
-        value={ingredientsText}
-        onChange={(e) => setIngredientsText(e.target.value)}
-        helperText="Introduce los ingredientes separados por comas"
-      />
-
-      <Input
-        label="Alérgenos (separados por coma)"
-        value={allergensText}
-        onChange={(e) => setAllergensText(e.target.value)}
-        helperText="Introduce los alérgenos separados por comas"
-      />
 
 
       <div className="flex justify-end">

--- a/src/components/Product/StockUpdateForm.tsx
+++ b/src/components/Product/StockUpdateForm.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { Product } from '../../types/product';
+import Input from '../shared/Input';
+import Button from '../shared/Button';
+
+interface StockUpdateFormProps {
+  products: Product[];
+  onSubmit: (updates: { id: string; stock: number }[]) => Promise<void>;
+  isLoading?: boolean;
+}
+
+const StockUpdateForm: React.FC<StockUpdateFormProps> = ({ products, onSubmit, isLoading = false }) => {
+  const [stockValues, setStockValues] = useState<Record<string, number>>(() => {
+    const initial: Record<string, number> = {};
+    products.forEach(p => {
+      initial[p.id] = p.stock;
+    });
+    return initial;
+  });
+
+  const handleChange = (id: string, value: number) => {
+    setStockValues(prev => ({ ...prev, [id]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const updates = products.map(p => ({ id: p.id, stock: stockValues[p.id] }));
+    await onSubmit(updates);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {products.map(product => (
+        <div key={product.id}>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            {product.name}
+          </label>
+          <Input
+            type="number"
+            value={stockValues[product.id]}
+            onChange={(e) => handleChange(product.id, Number(e.target.value))}
+          />
+        </div>
+      ))}
+      <div className="flex justify-end">
+        <Button type="submit" loading={isLoading}>
+          Guardar Cambios
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+export default StockUpdateForm;

--- a/src/pages/Admin/Products.tsx
+++ b/src/pages/Admin/Products.tsx
@@ -7,6 +7,7 @@ import { formatPrice } from '../../utils/formatters';
 import Button from '../../components/shared/Button';
 import Input from '../../components/shared/Input';
 import ProductForm from '../../components/Product/ProductForm';
+import StockUpdateForm from '../../components/Product/StockUpdateForm';
 import placeholderImg from '../../utils/placeholder';
 
 const Products: React.FC = () => {
@@ -22,6 +23,7 @@ const Products: React.FC = () => {
 
   const [searchTerm, setSearchTerm] = useState('');
   const [showForm, setShowForm] = useState(false);
+  const [showStockForm, setShowStockForm] = useState(false);
   const [editingProduct, setEditingProduct] = useState<Product | null>(null);
 
   useEffect(() => {
@@ -73,7 +75,54 @@ const Products: React.FC = () => {
     setEditingProduct(null);
   };
 
-   if (showForm) {
+  const handleBulkStockUpdate = async (
+    updates: { id: string; stock: number }[]
+  ) => {
+    try {
+      for (const u of updates) {
+        const product = products.find(p => p.id === u.id);
+        if (!product) continue;
+        const data: ProductFormData = {
+          name: product.name,
+          description: product.description,
+          imageUrl: product.imageUrl,
+          price: product.price,
+          category: product.category,
+          stock: u.stock,
+          ingredients: product.ingredients,
+          allergens: product.allergens,
+        };
+        await updateProduct(product.id, data);
+      }
+      setShowStockForm(false);
+    } catch {
+      // error handled by store
+    }
+  };
+
+  if (showStockForm) {
+    return (
+      <div className="min-h-screen bg-gray-50 py-8">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between mb-8">
+            <h1 className="text-3xl font-bold text-gray-900">Actualizar Stock</h1>
+            <Button variant="outline" onClick={() => setShowStockForm(false)}>
+              Cancelar
+            </Button>
+          </div>
+          <div className="bg-white rounded-lg shadow-md p-6">
+            <StockUpdateForm
+              products={products}
+              onSubmit={handleBulkStockUpdate}
+              isLoading={isLoading}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (showForm) {
     return (
       <div className="min-h-screen bg-gray-50 py-8">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -103,13 +152,21 @@ const Products: React.FC = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Gestión de Productos</h1>
-          <Button
-            onClick={() => setShowForm(true)}
-            className="flex items-center space-x-2"
-          >
-            <Plus className="h-5 w-5" />
-            <span>Agregar Producto</span>
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              onClick={() => setShowForm(true)}
+              className="flex items-center space-x-2"
+            >
+              <Plus className="h-5 w-5" />
+              <span>Agregar Producto</span>
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => setShowStockForm(true)}
+            >
+              Actualizar Stock
+            </Button>
+          </div>
         </div>
 
         {error && (


### PR DESCRIPTION
## Summary
- remove ingredients and allergens fields from product form
- add bulk stock update form for admins
- show `Actualizar Stock` button on admin products page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ac9fb81948324ad1a24b22359935b