### PR TITLE
Add featured products carousel

### DIFF
--- a/src/components/Product/ProductForm.tsx
+++ b/src/components/Product/ProductForm.tsx
@@ -26,6 +26,7 @@ const ProductForm: React.FC<ProductFormProps> = ({
     stock: initialData?.stock ?? 0,
     ingredients: initialData?.ingredients || [],
     allergens: initialData?.allergens || [],
+    featured: initialData?.featured ?? false,
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -38,10 +39,10 @@ const ProductForm: React.FC<ProductFormProps> = ({
       HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
     >
   ) => {
-    const { name, value, type } = e.target;
+    const { name, value, type, checked } = e.target as HTMLInputElement;
     setFormData(prev => ({
       ...prev,
-      [name]: type === 'number' ? Number(value) : value,
+        [name]: type === 'number' ? Number(value) : type === 'checkbox' ? checked : value,
     }));
   };
 
@@ -74,6 +75,10 @@ const ProductForm: React.FC<ProductFormProps> = ({
           onChange={handleInputChange}
           required
         />
+        <label className="flex items-center space-x-2 text-sm">
+          <input type="checkbox" name="featured" checked={formData.featured} onChange={handleInputChange} className="h-4 w-4 text-amber-600 border-gray-300 rounded" />
+          <span>Destacado del día</span>
+        </label>
       </div>
 
       <div>

--- a/src/pages/Admin/ProductEdit.tsx
+++ b/src/pages/Admin/ProductEdit.tsx
@@ -22,6 +22,7 @@ const ProductEdit: React.FC = () => {
     stock: 0,
     description: '',
     imageUrl: '',
+    featured: false,
   });
 
   useEffect(() => {
@@ -34,17 +35,25 @@ const ProductEdit: React.FC = () => {
             stock: data.stock,
             description: data.description,
             imageUrl: data.imageUrl || '',
+            featured: data.featured || false,
           })
         )
         .catch((err) => console.error(err));
     }
   }, [id, isEdit]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value, type, checked } = e.target as HTMLInputElement;
     setForm((f) => ({
       ...f,
-      [name]: name === 'price' || name === 'stock' ? Number(value) : value,
+      [name]:
+        name === 'price' || name === 'stock'
+          ? Number(value)
+          : type === 'checkbox'
+            ? checked
+            : value,
     }));
   };
 
@@ -91,6 +100,10 @@ const ProductEdit: React.FC = () => {
           onChange={handleChange}
           required
         />
+        <label className="flex items-center space-x-2 text-sm">
+          <input type="checkbox" name="featured" checked={form.featured} onChange={handleChange} className="h-4 w-4 text-amber-600 border-gray-300 rounded" />
+          <span>Destacado del día</span>
+        </label>
         <Input
           label="Descripción"
           name="description"

--- a/src/pages/Admin/Products.tsx
+++ b/src/pages/Admin/Products.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
-import { Plus, Edit, Trash2, Search } from 'lucide-react';
+import { Plus, Edit, Trash2, Search, Star } from 'lucide-react';
 import { useProductStore } from '../../store/useProductStore';
 import { Product, ProductFormData } from '../../types/product';
 import { formatPrice } from '../../utils/formatters';
@@ -17,6 +17,7 @@ const Products: React.FC = () => {
     createProduct,
     updateProduct,
     deleteProduct,
+    toggleFeatured,
     isLoading,
     error,
   } = useProductStore();
@@ -248,6 +249,13 @@ const Products: React.FC = () => {
                   >
                     <Trash2 className="h-4 w-4" />
                   </button>
+                  <button
+                    onClick={() => toggleFeatured(product.id, !product.featured)}
+                    className={product.featured ? 'text-amber-500' : 'text-gray-300'}
+                    aria-label="Marcar destacado"
+                  >
+                    <Star className={`h-4 w-4${product.featured ? ' fill-amber-400' : ''}`} />
+                  </button>
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-gray-100 text-gray-800 capitalize">
@@ -291,6 +299,9 @@ const Products: React.FC = () => {
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Stock
                   </th>
+                  <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                    Destacado
+                  </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                     Acciones
                   </th>
@@ -316,13 +327,16 @@ const Products: React.FC = () => {
                         <div className="h-4 bg-gray-200 rounded w-12"></div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="h-4 bg-gray-200 rounded w-16"></div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                        <div className="flex justify-end space-x-2">
-                          <div className="h-8 w-8 bg-gray-200 rounded"></div>
-                          <div className="h-8 w-8 bg-gray-200 rounded"></div>
-                        </div>
+                    <div className="h-4 bg-gray-200 rounded w-16"></div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-center">
+                    <div className="h-4 w-4 bg-gray-200 rounded mx-auto"></div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                    <div className="flex justify-end space-x-2">
+                      <div className="h-8 w-8 bg-gray-200 rounded"></div>
+                      <div className="h-8 w-8 bg-gray-200 rounded"></div>
+                    </div>
                       </td>
                     </tr>
                   ))
@@ -375,6 +389,15 @@ const Products: React.FC = () => {
                         >
                           {product.stock}
                         </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-center">
+                        <button
+                          onClick={() => toggleFeatured(product.id, !product.featured)}
+                          className={product.featured ? 'text-amber-500' : 'text-gray-300'}
+                          aria-label="Marcar destacado"
+                        >
+                          <Star className={`h-5 w-5${product.featured ? ' fill-amber-400' : ''}`} />
+                        </button>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <div className="flex justify-end space-x-2">

--- a/src/pages/Shop.tsx
+++ b/src/pages/Shop.tsx
@@ -25,6 +25,8 @@ const Shop: React.FC = () => {
     return matchesSearch && matchesCategory;
   });
 
+  const featuredProducts = products.filter(p => p.featured).slice(0, 3);
+
   const categories = useMemo(() => {
     const labelMap: Record<string, string> = {
       bread: 'Pan',
@@ -76,6 +78,19 @@ const Shop: React.FC = () => {
             Descubre nuestra selección de panes, pasteles y postres recién horneados con los mejores ingredientes.
           </p>
         </div>
+
+        {featuredProducts.length > 0 && (
+          <div className="mb-8">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4">Destacados del día</h2>
+            <div className="flex space-x-4 overflow-x-auto pb-2">
+              {featuredProducts.map(prod => (
+                <div key={prod.id} className="flex-shrink-0 w-64">
+                  <ProductCard product={prod} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Search and Filter */}
         <div className="flex flex-col md:flex-row gap-4 mb-8">

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -13,6 +13,7 @@ export interface Product {
   allergens?: string[];
   createdAt: string;
   updatedAt: string;
+  featured?: boolean;
 }
 
 export interface ProductFormData {
@@ -24,4 +25,5 @@ export interface ProductFormData {
   stock: number;    // ← formulario de admin debe enviar stock
   ingredients?: string[];
   allergens?: string[];
+  featured?: boolean;
 }

--- a/src/utils/mapApiProduct.ts
+++ b/src/utils/mapApiProduct.ts
@@ -5,5 +5,6 @@ export function mapApiProduct(apiProduct: any): Product {
     ...apiProduct,
     imageUrl: apiProduct.imageUrl ?? apiProduct.image_url ?? '',
     inStock: apiProduct.stock > 0,
+    featured: apiProduct.featured ?? false,
   } as Product;
 }


### PR DESCRIPTION
## Summary
- extend product data with featured flag
- support featured flag in API mapping and product forms
- allow toggling featured items from admin product list
- show featured products carousel on shop page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ae4831c288324bb1ac59c7d155578