### PR TITLE
Add delivery/pickup option

### DIFF
--- a/src/pages/Admin/OrderManagement.tsx
+++ b/src/pages/Admin/OrderManagement.tsx
@@ -162,6 +162,11 @@ const OrderManagement: React.FC = () => {
                         <div className="text-xs text-gray-500">
                           {o.customer?.address || "—"}
                         </div>
+                        {o.isDelivery !== undefined && (
+                          <div className="text-xs text-gray-500">
+                            {o.isDelivery ? 'Delivery' : 'Recoger en tienda'}
+                          </div>
+                        )}
                         {o.paymentMethod && (
                           <div className="flex items-center gap-1 text-xs text-gray-500">
                             <PaymentMethodIcon

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -16,6 +16,7 @@ interface FormData {
   address: string;
   paymentMethod: 'yape' | 'cash' | '';
   cashAmount?: string;
+  isDelivery: boolean;
 }
 const Checkout: React.FC = () => {
   const navigate = useNavigate();
@@ -58,6 +59,7 @@ const Checkout: React.FC = () => {
     address: '',
     paymentMethod: '',
     cashAmount: '',
+    isDelivery: true,
   });
 
 
@@ -69,7 +71,7 @@ const Checkout: React.FC = () => {
     const { name, value } = e.target;
     setFormData(prev => ({
       ...prev,
-      [name]: value,
+      [name]: name === 'isDelivery' ? value === 'delivery' : value,
       ...(name === 'paymentMethod' && value !== 'cash' ? { cashAmount: '' } : {})
     }));
   };
@@ -99,6 +101,7 @@ const Checkout: React.FC = () => {
       ...(formData.paymentMethod === 'cash'
         ? { cashAmount: Number(formData.cashAmount || 0) }
         : {}),
+      isDelivery: formData.isDelivery,
       // Enviar la información de contacto tanto de manera anidada
       // como en la raíz para maximizar compatibilidad con la API
       name: formData.name,
@@ -228,6 +231,21 @@ const Checkout: React.FC = () => {
                     </p>
                   </div>
                 )}
+                <div>
+                  <label htmlFor="isDelivery" className="block mb-1 text-gray-700">
+                    Entrega
+                  </label>
+                  <select
+                    id="isDelivery"
+                    name="isDelivery"
+                    value={formData.isDelivery ? 'delivery' : 'pickup'}
+                    onChange={handleChange}
+                    className="w-full border border-gray-300 px-3 py-2 rounded focus:outline-none focus:ring focus:border-blue-300"
+                  >
+                    <option value="delivery">Delivery</option>
+                    <option value="pickup">Recoger en tienda</option>
+                  </select>
+                </div>
               </div>
             </div>
           </div>

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -59,6 +59,7 @@ export interface Order {
   paymentMethod?: string;
   cashAmount?: number;
   reason?: string;
+  isDelivery?: boolean;
 }
 
 export interface CheckoutData {
@@ -74,4 +75,5 @@ export interface CheckoutData {
     phone: string;
     address: string;
   };
+  isDelivery?: boolean;
 }

--- a/src/utils/mapApiOrder.ts
+++ b/src/utils/mapApiOrder.ts
@@ -99,5 +99,10 @@ export function mapApiOrder(apiOrder: any): Order {
       apiOrder.paymentMethod ?? apiOrder.payment_method ?? undefined,
     cashAmount: apiOrder.cashAmount ?? apiOrder.cash_amount ?? undefined,
     reason: apiOrder.reason ?? apiOrder.rejectionReason ?? apiOrder.rejection_reason ?? undefined,
+    isDelivery:
+      apiOrder.isDelivery ??
+      apiOrder.is_delivery ??
+      apiOrder.delivery ??
+      undefined,
   } as Order;
 }


### PR DESCRIPTION
## Summary
- add `isDelivery` field to order types
- handle `isDelivery` in mapApiOrder
- extend checkout form so user can choose Delivery or pickup
- show delivery/pickup info in admin order list

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685af21f86cc83249cbf14c3a7c94815