### PR TITLE
Add show password toggle to auth forms

### DIFF
--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -4,12 +4,14 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
   helperText?: string;
+  rightIcon?: React.ReactNode;
 }
 
 const Input: React.FC<InputProps> = ({
   label,
   error,
   helperText,
+  rightIcon,
   className = '',
   id,
   ...props
@@ -23,19 +25,27 @@ const Input: React.FC<InputProps> = ({
           {label}
         </label>
       )}
-      <input
-        id={inputId}
-        className={`
-          w-full px-3 py-2 border rounded-lg shadow-sm placeholder-gray-400
-          focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent
-          ${error 
-            ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500' 
-            : 'border-gray-300 focus:border-amber-500'
-          }
-          ${className}
-        `}
-        {...props}
-      />
+      <div className="relative">
+        <input
+          id={inputId}
+          className={`
+            w-full px-3 py-2 border rounded-lg shadow-sm placeholder-gray-400
+            focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-transparent
+            ${error
+              ? 'border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500'
+              : 'border-gray-300 focus:border-amber-500'
+            }
+            ${rightIcon ? 'pr-10' : ''}
+            ${className}
+          `}
+          {...props}
+        />
+        {rightIcon && (
+          <span className="absolute inset-y-0 right-0 flex items-center pr-3">
+            {rightIcon}
+          </span>
+        )}
+      </div>
       {error && (
         <p className="text-sm text-red-600">{error}</p>
       )}


### PR DESCRIPTION
## Summary
- allow Input to display a right icon
- use the new feature in Login and Register to toggle password visibility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b007fddd88324a2e5357a0595bd9c